### PR TITLE
Adjust incoming solar radiation for slope and aspect

### DIFF
--- a/run/namelist.input
+++ b/run/namelist.input
@@ -18,6 +18,8 @@
 &location ! for point runs, needs to be modified for gridded
   lat              = 40.01    ! latitude [degrees]
   lon              = -88.37  ! longitude [degrees]
+  terrain_slope    = 0.0      ! terrain slope [degrees]
+  azimuth          = 0.0      ! terrain azimuth or aspect [degrees clockwise from north]
 /
 
 &forcing

--- a/src/DomainType.f90
+++ b/src/DomainType.f90
@@ -25,6 +25,8 @@ type, public :: domain_type
   real                :: lat               ! latitude (°)
   real                :: lon               ! longitude (°)
   real                :: ZREF              ! measurement height of wind speed (m)
+  real                :: terrain_slope     ! terrain slope (°)
+  real                :: azimuth           ! terrain azimuth or aspect (° clockwise from north)
   integer             :: vegtyp            ! land cover type
   integer             :: croptype          ! crop type
   integer             :: isltyp            ! soil type
@@ -70,25 +72,27 @@ contains
 
     class(domain_type) :: this
 
-    this%iloc      = huge(1)
-    this%jloc      = huge(1)
-    this%dt        = huge(1.0)
-    this%startdate = 'EMPTYDATE999'
-    this%enddate   = 'EMPTYDATE999'
-    this%nowdate   = 'EMPTYDATE999'
+    this%iloc           = huge(1)
+    this%jloc           = huge(1)
+    this%dt             = huge(1.0)
+    this%startdate      = 'EMPTYDATE999'
+    this%enddate        = 'EMPTYDATE999'
+    this%nowdate        = 'EMPTYDATE999'
     this%start_datetime = huge(1)
     this%end_datetime   = huge(1)
     this%curr_datetime  = huge(1)
-    this%itime     = huge(1) 
-    this%ntime     = huge(1) 
-    this%time_dbl  = huge(1.d0)
-    this%lat       = huge(1.0)
-    this%lon       = huge(1.0)
-    this%ZREF      = huge(1.0)
-    this%vegtyp    = huge(1)
-    this%croptype  = huge(1)
-    this%isltyp    = huge(1)
-    this%IST       = huge(1)
+    this%itime          = huge(1) 
+    this%ntime          = huge(1) 
+    this%time_dbl       = huge(1.d0)
+    this%lat            = huge(1.0)
+    this%lon            = huge(1.0)
+    this%terrain_slope  = huge(1.0)
+    this%azimuth        = huge(1.0)
+    this%ZREF           = huge(1.0)
+    this%vegtyp         = huge(1)
+    this%croptype       = huge(1)
+    this%isltyp         = huge(1)
+    this%IST            = huge(1)
 
 
   end subroutine InitDefault
@@ -98,18 +102,20 @@ contains
     class(domain_type)  :: this
     type(namelist_type) :: namelist
 
-    this%dt        = namelist%dt
-    this%startdate = namelist%startdate
-    this%enddate   = namelist%enddate
-    this%lat       = namelist%lat
-    this%lon       = namelist%lon
-    this%ZREF      = namelist%ZREF
-    this%zsoil     = namelist%zsoil
-    this%dzsnso    = namelist%dzsnso
-    this%vegtyp    = namelist%vegtyp
-    this%croptype  = namelist%croptype
-    this%isltyp    = namelist%isltyp
-    this%IST       = namelist%sfctyp
+    this%dt             = namelist%dt
+    this%startdate      = namelist%startdate
+    this%enddate        = namelist%enddate
+    this%lat            = namelist%lat
+    this%lon            = namelist%lon
+    this%terrain_slope  = namelist%terrain_slope
+    this%azimuth        = namelist%azimuth
+    this%ZREF           = namelist%ZREF
+    this%zsoil          = namelist%zsoil
+    this%dzsnso         = namelist%dzsnso
+    this%vegtyp         = namelist%vegtyp
+    this%croptype       = namelist%croptype
+    this%isltyp         = namelist%isltyp
+    this%IST            = namelist%sfctyp
     this%start_datetime = date_to_unix(namelist%startdate)  ! returns seconds-since-1970-01-01
     this%end_datetime   = date_to_unix(namelist%enddate)
   

--- a/src/NamelistRead.f90
+++ b/src/NamelistRead.f90
@@ -19,6 +19,8 @@ type, public :: namelist_type
   character(len=256) :: veg_class_name     ! name of vegetation classification (MODIFIED_IGBP_MODIS_NOAH or USGS)
   real               :: lat                ! latitude (°)
   real               :: lon                ! longitude (°)
+  real               :: terrain_slope      ! terrain slope (°)
+  real               :: azimuth            ! terrain azimuth or aspect (° clockwise from north)
   real               :: ZREF               ! measurement height for wind speed (m)
 
   integer            :: isltyp             ! soil type
@@ -95,6 +97,8 @@ contains
     character(len=256) :: soil_class_name
     real               :: lat
     real               :: lon
+    real               :: terrain_slope
+    real               :: azimuth
     real               :: ZREF               ! measurement height for wind speed (m)
 
     integer       :: isltyp
@@ -142,7 +146,7 @@ contains
 
     namelist / timing          / dt,startdate,enddate,input_filename,output_filename
     namelist / parameters      / parameter_dir, soil_table, general_table, noahowp_table, soil_class_name, veg_class_name
-    namelist / location        / lat,lon
+    namelist / location        / lat,lon,terrain_slope,azimuth
     namelist / forcing         / ZREF
     namelist / model_options   / precip_phase_option,runoff_option,drainage_option,frozen_soil_option,dynamic_vic_option,&
                                  dynamic_veg_option,snow_albedo_option,radiative_transfer_option,sfc_drag_coeff_option,&
@@ -213,6 +217,8 @@ contains
     this%veg_class_name     = veg_class_name
     this%lat                = lat
     this%lon                = lon
+    this%terrain_slope      = terrain_slope
+    this%azimuth            = azimuth
     this%ZREF               = ZREF
 
     this%isltyp           = isltyp


### PR DESCRIPTION
This PR updates Noah-OWP-Modular to account for slope and aspect when computing incoming solar radiation. Previously the model assumed a flat domain, meaning it could not resolve the effects of topography on various hydrologic processes.

Files changed:

-`src/UtilitiesModule.f90` (modified equations for `COSZ`)
-`src/NamelistRead.f90` (read in slope/aspect)
-`src/DomainType.f90` (add slope/aspect)
-`run/namelist.input` (add slope/aspect)

If you want to run Noah-OWP-Modular assuming flat topography, you can just set `terrain_slope` and `azimuth` in `namelist.input` to 0.0.

Closes #47