### PR TITLE
New precipitation phase options for Noah-OWP-Modular

### DIFF
--- a/run/namelist.input
+++ b/run/namelist.input
@@ -23,7 +23,8 @@
 /
 
 &forcing
-  ZREF            = 10.0    ! measurement height for wind speed
+  ZREF             = 10.0    ! measurement height for wind speed
+  rain_snow_thresh = 1.0     ! rain-snow temperature threshold (°C)
 /
 
 &model_options ! see OptionsType.f90 for details

--- a/src/AtmProcessing.f90
+++ b/src/AtmProcessing.f90
@@ -101,10 +101,10 @@ contains
   
     ! First compute relative humidity for options that need it
     ! Used in opt_snf 6 and 7
-    IF(options%OPT_SNF == 6 .or. options%OPT_SNF == 7)
+    IF(options%OPT_SNF == 6 .or. options%OPT_SNF == 7) THEN
       rh = 0.263 * forcing%SFCPRS * forcing%Q2 * &
            ((exp((17.67 * (forcing%SFCTMP - 273.15)) / (forcing%SFCTMP - 29.65)))**-1)
-      rh = min(rh, 100) ! in case estimated rh > 100     
+      rh = min(rh, 100.0) ! in case estimated rh > 100     
     ENDIF
     
     ! select the precipitation phase partitioning method and compute FPICE

--- a/src/NamelistRead.f90
+++ b/src/NamelistRead.f90
@@ -22,6 +22,7 @@ type, public :: namelist_type
   real               :: terrain_slope      ! terrain slope (°)
   real               :: azimuth            ! terrain azimuth or aspect (° clockwise from north)
   real               :: ZREF               ! measurement height for wind speed (m)
+  real               :: rain_snow_thresh   ! rain-snow temperature threshold (°C)
 
   integer            :: isltyp             ! soil type
   integer            :: nsoil              ! number of soil layers
@@ -100,6 +101,7 @@ contains
     real               :: terrain_slope
     real               :: azimuth
     real               :: ZREF               ! measurement height for wind speed (m)
+    real               :: rain_snow_thresh
 
     integer       :: isltyp
     integer       :: nsoil
@@ -147,7 +149,7 @@ contains
     namelist / timing          / dt,startdate,enddate,input_filename,output_filename
     namelist / parameters      / parameter_dir, soil_table, general_table, noahowp_table, soil_class_name, veg_class_name
     namelist / location        / lat,lon,terrain_slope,azimuth
-    namelist / forcing         / ZREF
+    namelist / forcing         / ZREF,rain_snow_thresh
     namelist / model_options   / precip_phase_option,runoff_option,drainage_option,frozen_soil_option,dynamic_vic_option,&
                                  dynamic_veg_option,snow_albedo_option,radiative_transfer_option,sfc_drag_coeff_option,&
                                  canopy_stom_resist_option,crop_model_option,snowsoil_temp_time_option,soil_temp_boundary_option,&
@@ -220,6 +222,7 @@ contains
     this%terrain_slope      = terrain_slope
     this%azimuth            = azimuth
     this%ZREF               = ZREF
+    this%rain_snow_thresh   = rain_snow_thresh
 
     this%isltyp           = isltyp
     this%nsoil            = nsoil

--- a/src/OptionsType.f90
+++ b/src/OptionsType.f90
@@ -13,6 +13,9 @@ type, public :: options_type
                         !   2 -> rain-snow air temperature threshold of 2.2°C
                         !   3 -> rain-snow air temperature threshold of 0°C
                         !   4 -> precipitation phase from weather model
+                        !   5 -> user-defined air temperature threshold
+                        !   6 -> user-defined wet bulb temperature threshold
+                        !   7 -> binary logistic regression model from Jennings et al. (2018)
   integer :: opt_run    ! runoff_option: options for runoff
                         !   1 -> TOPMODEL with groundwater (Niu et al. 2007 JGR)
                         !   2 -> TOPMODEL with an equilibrium water table (Niu et al. 2005 JGR)

--- a/src/ParametersType.f90
+++ b/src/ParametersType.f90
@@ -358,7 +358,16 @@ contains
     this%PSIWLT    = -150.0      ! originally a fixed parameter set in ENERGY()
     this%TBOT      = 263.0       ! (K) can be updated depending on option OPT_TBOT
     
-    this%rain_snow_thresh = namelist%rain_snow_thresh ! assign threshold from namelist
+    ! Assign rain-snow threshold based on option
+    IF(namelist%precip_phase_option == 2) THEN
+      this%rain_snow_thresh = this%TFRZ + 2.2
+    ELSE IF(namelist%precip_phase_option == 3) THEN
+      this%rain_snow_thresh = this%TFRZ
+    ELSE IF(namelist%precip_phase_option == 5 .or. namelist%precip_phase_option == 6)
+      this%rain_snow_thresh = this%TFRZ + namelist%rain_snow_thresh
+    ELSE 
+      rs_thresh = this%TFRZ ! set to TFRZ as a backup
+    ENDIF
     
     ! Assign initial soil moisture based on variable or uniform initial conditions
     if(namelist%initial_uniform) then

--- a/src/ParametersType.f90
+++ b/src/ParametersType.f90
@@ -141,6 +141,7 @@ type, public :: parameters_type
   real                            :: PSIWLT                    ! matric potential for wilting point (m)  (orig a fixed param.)
   real                            :: TBOT                      ! bottom condition for soil temp. (k)
   real                            :: GRAV                      ! acceleration due to gravity (m/s2)
+  real                            :: rain_snow_thresh          ! user-defined rain-snow temperature threshold (°C)
 
   contains
 
@@ -356,6 +357,8 @@ contains
     this%O2        =  0.209      ! o2 partial pressure, from O2_TABLE var (set in MPTABLE.TBL)
     this%PSIWLT    = -150.0      ! originally a fixed parameter set in ENERGY()
     this%TBOT      = 263.0       ! (K) can be updated depending on option OPT_TBOT
+    
+    this%rain_snow_thresh = namelist%rain_snow_thresh ! assign threshold from namelist
     
     ! Assign initial soil moisture based on variable or uniform initial conditions
     if(namelist%initial_uniform) then

--- a/src/ParametersType.f90
+++ b/src/ParametersType.f90
@@ -363,10 +363,10 @@ contains
       this%rain_snow_thresh = this%TFRZ + 2.2
     ELSE IF(namelist%precip_phase_option == 3) THEN
       this%rain_snow_thresh = this%TFRZ
-    ELSE IF(namelist%precip_phase_option == 5 .or. namelist%precip_phase_option == 6)
+    ELSE IF(namelist%precip_phase_option == 5 .or. namelist%precip_phase_option == 6) THEN
       this%rain_snow_thresh = this%TFRZ + namelist%rain_snow_thresh
     ELSE 
-      rs_thresh = this%TFRZ ! set to TFRZ as a backup
+      this%rain_snow_thresh = this%TFRZ ! set to TFRZ as a backup
     ENDIF
     
     ! Assign initial soil moisture based on variable or uniform initial conditions


### PR DESCRIPTION
This PR includes three new options for partitioning precipitation into rainfall and snowfall:

- `opt_snf = 5`: User-defined air temperature threshold (provided in the namelist)
- `opt_snf = 6`: User-defined wet bulb temperature threshold (provided in the namelist)
- `opt_snf = 7`: Snowfall probability computed from optimized binary logistic regression model ([Jennings et al., 2018](https://doi.org/10.1038/s41467-018-03629-7))

The PR also includes modifications that:

- Compute relative humidity as f(air temperature, specific humidity) and wet bulb temperature as f(air temperature, relative humidity), the latter of which uses the [Stull (2011)](https://doi.org/10.1175/JAMC-D-11-0143.1) method
- Streamline the code for precipitation phase methods that use a default or user-defined threshold

We kept options 1 through 4 the same to ensure backwards compatibility.