### PR TITLE
Modifying incoming shortwave radiation to account for slope and aspect

### DIFF
--- a/driver/OutputModule.f90
+++ b/driver/OutputModule.f90
@@ -59,6 +59,7 @@ module OutputModule
   integer           :: stc_id
   integer           :: zsnso_id
   ! energy
+  integer           :: swin_id
   integer           :: lh_id
   integer           :: t2m_id
   integer           :: t2mb_id
@@ -131,6 +132,7 @@ contains
     iret = nf90_def_var(ncid, "ZSNSO",                NF90_FLOAT, (/time_dim,snso_dim/), zsnso_id)
     
     ! energy
+    iret = nf90_def_var(ncid, "SW_IN",                NF90_FLOAT, (/time_dim/), swin_id)  ! incoming shortwave, corrected for slope/aspect (W/m^2)
     iret = nf90_def_var(ncid, "LH",                   NF90_FLOAT, (/time_dim/), lh_id)  ! latent heat (W/m^2)
     iret = nf90_def_var(ncid, "T2M",                  NF90_FLOAT, (/time_dim/), t2m_id)  ! 2 m height air temperature (K) 
     iret = nf90_def_var(ncid, "T2MB",                 NF90_FLOAT, (/time_dim/), t2mb_id)  ! 2 m height air temperature (K) bare ground
@@ -206,6 +208,7 @@ contains
     iret = nf90_put_var(ncid, stc_id,     energy%stc,                 start=(/itime,1/), count=(/1,nsoil+nsnow/))
     iret = nf90_put_var(ncid, zsnso_id,   zsnso,                      start=(/itime,1/), count=(/1,nsoil+nsnow/))
     ! energy
+    iret = nf90_put_var(ncid, swin_id,    forcing%SWDOWN,             start=(/itime/))
     iret = nf90_put_var(ncid, lh_id,      energy%lh,                  start=(/itime/))
     iret = nf90_put_var(ncid, t2m_id,     energy%t2m,                 start=(/itime/))
     iret = nf90_put_var(ncid, t2mb_id,    energy%t2mb,                start=(/itime/))

--- a/src/EnergyType.f90
+++ b/src/EnergyType.f90
@@ -56,6 +56,7 @@ type, public :: energy_type
   
   ! Shortwave radiation
   real                 :: COSZ    ! cosine solar zenith angle [0-1]
+  real                 :: COSZ_HORIZ ! cosine solar zenith angle for flat ground [0-1]
   real                 :: BGAP    ! between canopy gap fraction for beam (-)
   real                 :: WGAP    ! within canopy gap fraction for beam (-)
   REAL                 :: FSUN    ! sunlit fraction of canopy (-)
@@ -228,6 +229,7 @@ contains
     this%ALBOLD    = huge(1.0)
     
     this%COSZ      = huge(1.0)
+    this%COSZ_HORIZ= huge(1.0)
     this%BGAP      = huge(1.0)
     this%WGAP      = huge(1.0)
     this%FSUN      = huge(1.0)

--- a/src/ShortwaveRadiationModule.f90
+++ b/src/ShortwaveRadiationModule.f90
@@ -39,7 +39,7 @@ contains
 
     ! Compute net solar radiation
     CALL NetSolarRadiation(domain, levels, options, parameters, forcing, energy, water)
-
+   
   END SUBROUTINE ShortwaveRadiationMain
   
   !== begin NetSolarRadiation, formerly SURRAD ===========================================

--- a/src/UtilitiesModule.f90
+++ b/src/UtilitiesModule.f90
@@ -34,7 +34,7 @@ contains
     ! calculate current declination of direct solar radiation input
     call calc_declin(domain%nowdate(1:4)//"-"//domain%nowdate(5:6)//"-"//domain%nowdate(7:8)//"_"//domain%nowdate(9:10)//":"//domain%nowdate(11:12)//":00", & ! in
                      domain%lat, domain%lon, domain%terrain_slope, domain%azimuth,&                                                                           ! in
-                     energy%cosz, forcing%yearlen, forcing%julian)                                                                                            ! out
+                     energy%cosz, energy%cosz_horiz,forcing%yearlen, forcing%julian)                                                                                            ! out
     
   END SUBROUTINE UtilitiesMain
 
@@ -807,7 +807,7 @@ contains
 
   SUBROUTINE calc_declin (nowdate, &                             ! in
                           latitude, longitude, slope, azimuth, & ! in
-                          cosz, yearlen, julian)                 ! out
+                          cosz, cosz_horiz, yearlen, julian)                 ! out
   !---------------------------------------------------------------------
     IMPLICIT NONE
   !---------------------------------------------------------------------
@@ -819,6 +819,7 @@ contains
     real,              intent(in)  :: slope      ! slope (degrees)
     real,              intent(in)  :: azimuth    ! azimuth (degrees)
     real,              intent(out) :: cosz       ! cosine of solar zenith angle
+    real,              intent(out) :: cosz_horiz ! cosine of solar zenith angle for flat ground
     integer,           intent(out) :: yearlen    ! year length
     real,              intent(out) :: JULIAN     ! julian day
 
@@ -909,6 +910,15 @@ contains
     ! Compute COSZ using the dot product of the two vectors
     ! Simplified here algebraically
     COSZ = (nvx * svx) + (nvy * svy) + (nvz * svz)
+    
+    ! We also need to know the flat ground COSZ to correct incoming solar radiation
+    ! which is typically assumed to be measured/modeled for a flat surface
+    ! for a horizontal plane, nvx = 0, nvy = 0, and nvz = 1 (svx, svy, svz are as calculated previously)
+    nvx = 0.0
+    nvy = 0.0
+    nvz = 1.0
+    COSZ_HORIZ = (nvx * svx) + (nvy * svy) + (nvz * svz)
+    
     
   END SUBROUTINE calc_declin
   


### PR DESCRIPTION
The previous PR, #48, only modified the `COSZ` variable to account for slope and aspect. Because Noah-OM did not previously account for `COSZ`'s effect on incoming shortwave radiation, the modification in #48 did not change `SWDOWN`.  

This PR further modifies the handling of SWDOWN to account for slope and aspect as the function of the ratio between COSZ and COSZ_HORIZ—i.e., the cosine of the incidence angle divided by the cosine of the solar zenith angle on flat ground ([Duguay, 1993](https://doi.org/10.2307/3673761)). We also include logic to protect against erroneously high and low SWDOWN values that may result. 

Files changed: 

- `driver/OutputModule.f90`
- `src/AtmProcessing.f90` 
- `src/EnergyType.f90` 
- `src/ShortwaveRadiationModule.f90` 
- `src/UtilitiesModule.f90`

Model output now shows that slope and aspect modify incoming shortwave radiation as expected. The figure below shows a time series of SWDOWN for two 25° slopes, one facing due south (red) and the other facing due north (blue):

<img width="852" alt="image" src="https://user-images.githubusercontent.com/32177682/170034701-1edc633a-0665-4075-9719-c762b2e02eec.png">

This has the expected effect of longer lasting snow cover (plotted as snow water equivalent, SWE) on the north-facing slope as shown in the figure below:

<img width="846" alt="image" src="https://user-images.githubusercontent.com/32177682/170035018-9e445a7e-fe47-4ddb-a60e-afe6c67153c5.png">

And we observe higher evaporation on the south-facing slope:

<img width="845" alt="image" src="https://user-images.githubusercontent.com/32177682/170035446-334f0290-52e9-43fa-9e94-fca4579e76a0.png">
