### PR TITLE
Merge snow-mods branch to main

### DIFF
--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -166,8 +166,9 @@ contains
     output_items(2) = 'ETRAN'      ! transpiration rate (mm/s)
     output_items(3) = 'QSEVA'      ! evaporation rate (m/s)
     output_items(4) = 'EVAPOTRANS' ! evapotranspiration rate (m/s)
-    output_items(5) = 'TG'         ! surface/ground temperature (K)
+    output_items(5) = 'TG'         ! surface/ground temperature (K) (becomes snow surface temperature when snow is present)
     output_items(6) = 'SNEQV'      ! snow water equivalent (mm)
+    output_items(7) = 'TGS'        ! ground temperature (K) (is equal to TG when no snow and equal to bottom snow element temperature when there is snow)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -286,7 +287,7 @@ contains
 
     select case(name)
     case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! input vars
-         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV')             ! output vars
+         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS')             ! output vars
        grid = 0
        bmi_status = BMI_SUCCESS
     case default
@@ -557,7 +558,7 @@ contains
 
     select case(name)
     case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! input vars
-         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV')             ! output vars
+         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS')             ! output vars
        type = "real"
        bmi_status = BMI_SUCCESS
     case default
@@ -577,7 +578,7 @@ contains
     case("SFCPRS")
        units = "Pa"
        bmi_status = BMI_SUCCESS
-    case("SFCTMP", "TG")
+    case("SFCTMP", "TG", "TGS")
        units = "K"
        bmi_status = BMI_SUCCESS
     case("SOLDN", "LWDN")
@@ -653,6 +654,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("SNEQV")
        size = sizeof(this%model%water%sneqv)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("TGS")
+       size = sizeof(this%model%energy%tgs)            ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case default
        size = -1
@@ -762,6 +766,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("SNEQV")
        dest = [this%model%water%sneqv]
+       bmi_status = BMI_SUCCESS
+    case("TGS")
+       dest = [this%model%energy%tgs]
        bmi_status = BMI_SUCCESS
     case default
        dest(:) = -1.0
@@ -973,6 +980,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("SNEQV")
        this%model%water%sneqv = src(1)
+       bmi_status = BMI_SUCCESS
+    case("TGS")
+       this%model%energy%tgs = src(1)
        bmi_status = BMI_SUCCESS
     case default
        bmi_status = BMI_FAILURE

--- a/driver/OutputModule.f90
+++ b/driver/OutputModule.f90
@@ -59,6 +59,7 @@ module OutputModule
   integer           :: stc_id
   integer           :: zsnso_id
   ! energy
+  integer           :: swin_id
   integer           :: lh_id
   integer           :: t2m_id
   integer           :: t2mb_id
@@ -131,6 +132,7 @@ contains
     iret = nf90_def_var(ncid, "ZSNSO",                NF90_FLOAT, (/time_dim,snso_dim/), zsnso_id)
     
     ! energy
+    iret = nf90_def_var(ncid, "SW_IN",                NF90_FLOAT, (/time_dim/), swin_id)  ! incoming shortwave, corrected for slope/aspect (W/m^2)
     iret = nf90_def_var(ncid, "LH",                   NF90_FLOAT, (/time_dim/), lh_id)  ! latent heat (W/m^2)
     iret = nf90_def_var(ncid, "T2M",                  NF90_FLOAT, (/time_dim/), t2m_id)  ! 2 m height air temperature (K) 
     iret = nf90_def_var(ncid, "T2MB",                 NF90_FLOAT, (/time_dim/), t2mb_id)  ! 2 m height air temperature (K) bare ground
@@ -206,6 +208,7 @@ contains
     iret = nf90_put_var(ncid, stc_id,     energy%stc,                 start=(/itime,1/), count=(/1,nsoil+nsnow/))
     iret = nf90_put_var(ncid, zsnso_id,   zsnso,                      start=(/itime,1/), count=(/1,nsoil+nsnow/))
     ! energy
+    iret = nf90_put_var(ncid, swin_id,    forcing%SWDOWN,             start=(/itime/))
     iret = nf90_put_var(ncid, lh_id,      energy%lh,                  start=(/itime/))
     iret = nf90_put_var(ncid, t2m_id,     energy%t2m,                 start=(/itime/))
     iret = nf90_put_var(ncid, t2mb_id,    energy%t2mb,                start=(/itime/))

--- a/run/namelist.input
+++ b/run/namelist.input
@@ -23,7 +23,8 @@
 /
 
 &forcing
-  ZREF            = 10.0    ! measurement height for wind speed
+  ZREF             = 10.0    ! measurement height for wind speed
+  rain_snow_thresh = 1.0     ! rain-snow temperature threshold (°C)
 /
 
 &model_options ! see OptionsType.f90 for details

--- a/run/namelist.input
+++ b/run/namelist.input
@@ -18,6 +18,8 @@
 &location ! for point runs, needs to be modified for gridded
   lat              = 40.01    ! latitude [degrees]
   lon              = -88.37  ! longitude [degrees]
+  terrain_slope    = 0.0      ! terrain slope [degrees]
+  azimuth          = 0.0      ! terrain azimuth or aspect [degrees clockwise from north]
 /
 
 &forcing

--- a/src/AtmProcessing.f90
+++ b/src/AtmProcessing.f90
@@ -101,10 +101,10 @@ contains
   
     ! First compute relative humidity for options that need it
     ! Used in opt_snf 6 and 7
-    IF(options%OPT_SNF == 6 .or. options%OPT_SNF == 7)
+    IF(options%OPT_SNF == 6 .or. options%OPT_SNF == 7) THEN
       rh = 0.263 * forcing%SFCPRS * forcing%Q2 * &
            ((exp((17.67 * (forcing%SFCTMP - 273.15)) / (forcing%SFCTMP - 29.65)))**-1)
-      rh = min(rh, 100) ! in case estimated rh > 100     
+      rh = min(rh, 100.0) ! in case estimated rh > 100     
     ENDIF
     
     ! select the precipitation phase partitioning method and compute FPICE

--- a/src/DomainType.f90
+++ b/src/DomainType.f90
@@ -25,6 +25,8 @@ type, public :: domain_type
   real                :: lat               ! latitude (°)
   real                :: lon               ! longitude (°)
   real                :: ZREF              ! measurement height of wind speed (m)
+  real                :: terrain_slope     ! terrain slope (°)
+  real                :: azimuth           ! terrain azimuth or aspect (° clockwise from north)
   integer             :: vegtyp            ! land cover type
   integer             :: croptype          ! crop type
   integer             :: isltyp            ! soil type
@@ -70,25 +72,27 @@ contains
 
     class(domain_type) :: this
 
-    this%iloc      = huge(1)
-    this%jloc      = huge(1)
-    this%dt        = huge(1.0)
-    this%startdate = 'EMPTYDATE999'
-    this%enddate   = 'EMPTYDATE999'
-    this%nowdate   = 'EMPTYDATE999'
+    this%iloc           = huge(1)
+    this%jloc           = huge(1)
+    this%dt             = huge(1.0)
+    this%startdate      = 'EMPTYDATE999'
+    this%enddate        = 'EMPTYDATE999'
+    this%nowdate        = 'EMPTYDATE999'
     this%start_datetime = huge(1)
     this%end_datetime   = huge(1)
     this%curr_datetime  = huge(1)
-    this%itime     = huge(1) 
-    this%ntime     = huge(1) 
-    this%time_dbl  = huge(1.d0)
-    this%lat       = huge(1.0)
-    this%lon       = huge(1.0)
-    this%ZREF      = huge(1.0)
-    this%vegtyp    = huge(1)
-    this%croptype  = huge(1)
-    this%isltyp    = huge(1)
-    this%IST       = huge(1)
+    this%itime          = huge(1) 
+    this%ntime          = huge(1) 
+    this%time_dbl       = huge(1.d0)
+    this%lat            = huge(1.0)
+    this%lon            = huge(1.0)
+    this%terrain_slope  = huge(1.0)
+    this%azimuth        = huge(1.0)
+    this%ZREF           = huge(1.0)
+    this%vegtyp         = huge(1)
+    this%croptype       = huge(1)
+    this%isltyp         = huge(1)
+    this%IST            = huge(1)
 
 
   end subroutine InitDefault
@@ -98,18 +102,20 @@ contains
     class(domain_type)  :: this
     type(namelist_type) :: namelist
 
-    this%dt        = namelist%dt
-    this%startdate = namelist%startdate
-    this%enddate   = namelist%enddate
-    this%lat       = namelist%lat
-    this%lon       = namelist%lon
-    this%ZREF      = namelist%ZREF
-    this%zsoil     = namelist%zsoil
-    this%dzsnso    = namelist%dzsnso
-    this%vegtyp    = namelist%vegtyp
-    this%croptype  = namelist%croptype
-    this%isltyp    = namelist%isltyp
-    this%IST       = namelist%sfctyp
+    this%dt             = namelist%dt
+    this%startdate      = namelist%startdate
+    this%enddate        = namelist%enddate
+    this%lat            = namelist%lat
+    this%lon            = namelist%lon
+    this%terrain_slope  = namelist%terrain_slope
+    this%azimuth        = namelist%azimuth
+    this%ZREF           = namelist%ZREF
+    this%zsoil          = namelist%zsoil
+    this%dzsnso         = namelist%dzsnso
+    this%vegtyp         = namelist%vegtyp
+    this%croptype       = namelist%croptype
+    this%isltyp         = namelist%isltyp
+    this%IST            = namelist%sfctyp
     this%start_datetime = date_to_unix(namelist%startdate)  ! returns seconds-since-1970-01-01
     this%end_datetime   = date_to_unix(namelist%enddate)
   

--- a/src/EnergyModule.f90
+++ b/src/EnergyModule.f90
@@ -348,6 +348,15 @@ contains
     
     ! derived diagnostic variables
     energy%LH = energy%FCEV + energy%FGEV + energy%FCTR
+    
+    ! Compute TGS, or ground surface temperature for passing to a subsurface module
+    ! TGS is equal to TG when SNOWH <= 0.05 and equal to the temperature of the bottom snow
+    ! element when SNOWH > 0.05
+    IF (water%SNOWH <= 0.05) THEN
+      energy%TGS = energy%TG
+    ELSE
+      energy%TGS = energy%STC(0)
+    END IF
 
   END SUBROUTINE EnergyMain   
 

--- a/src/EnergyModule.f90
+++ b/src/EnergyModule.f90
@@ -352,10 +352,10 @@ contains
     ! Compute TGS, or ground surface temperature for passing to a subsurface module
     ! TGS is equal to TG when SNOWH <= 0.05 and equal to the temperature of the bottom snow
     ! element when SNOWH > 0.05
-    IF (water%SNOWH <= 0.05) THEN
-      energy%TGS = energy%TG
-    ELSE
+    IF (water%SNOWH > 0.05) THEN
       energy%TGS = energy%STC(0)
+    ELSE
+      energy%TGS = energy%TG
     END IF
 
   END SUBROUTINE EnergyMain   

--- a/src/EnergyType.f90
+++ b/src/EnergyType.f90
@@ -148,6 +148,9 @@ type, public :: energy_type
   REAL                 :: QMELT   ! snowmelt [mm/s]
   
   REAL                 :: LH      ! latent heat (total) flux [W m-2]
+  REAL                 :: TGS     ! ground surface temperature (K, takes value of TG when SNOWH <= 0.05 and STC[0] when SNOWH > 0.05) 
+                                  ! this is a temporary fix for when coupled to subsurface modules
+                                  ! TODO: further investigation
   
 
   integer              :: ICE     ! 1 if sea ice, -1 if glacier, 0 if no land ice (seasonal snow)
@@ -321,7 +324,8 @@ contains
     this%APAR      = huge(1.0)
     this%QMELT     = huge(1.0)
 
-    this%LH        = huge(1)    
+    this%LH        = huge(1.0)    
+    this%TGS       = huge(1.0)    
     
     this%ICE       = huge(1)    
     

--- a/src/EnergyType.f90
+++ b/src/EnergyType.f90
@@ -56,6 +56,7 @@ type, public :: energy_type
   
   ! Shortwave radiation
   real                 :: COSZ    ! cosine solar zenith angle [0-1]
+  real                 :: COSZ_HORIZ ! cosine solar zenith angle for flat ground [0-1]
   real                 :: BGAP    ! between canopy gap fraction for beam (-)
   real                 :: WGAP    ! within canopy gap fraction for beam (-)
   REAL                 :: FSUN    ! sunlit fraction of canopy (-)
@@ -228,6 +229,7 @@ contains
     this%ALBOLD    = huge(1.0)
     
     this%COSZ      = huge(1.0)
+    this%COSZ_HORIZ= huge(1.0)
     this%BGAP      = huge(1.0)
     this%WGAP      = huge(1.0)
     this%FSUN      = huge(1.0)

--- a/src/NamelistRead.f90
+++ b/src/NamelistRead.f90
@@ -19,6 +19,8 @@ type, public :: namelist_type
   character(len=256) :: veg_class_name     ! name of vegetation classification (MODIFIED_IGBP_MODIS_NOAH or USGS)
   real               :: lat                ! latitude (°)
   real               :: lon                ! longitude (°)
+  real               :: terrain_slope      ! terrain slope (°)
+  real               :: azimuth            ! terrain azimuth or aspect (° clockwise from north)
   real               :: ZREF               ! measurement height for wind speed (m)
 
   integer            :: isltyp             ! soil type
@@ -95,6 +97,8 @@ contains
     character(len=256) :: soil_class_name
     real               :: lat
     real               :: lon
+    real               :: terrain_slope
+    real               :: azimuth
     real               :: ZREF               ! measurement height for wind speed (m)
 
     integer       :: isltyp
@@ -142,7 +146,7 @@ contains
 
     namelist / timing          / dt,startdate,enddate,input_filename,output_filename
     namelist / parameters      / parameter_dir, soil_table, general_table, noahowp_table, soil_class_name, veg_class_name
-    namelist / location        / lat,lon
+    namelist / location        / lat,lon,terrain_slope,azimuth
     namelist / forcing         / ZREF
     namelist / model_options   / precip_phase_option,runoff_option,drainage_option,frozen_soil_option,dynamic_vic_option,&
                                  dynamic_veg_option,snow_albedo_option,radiative_transfer_option,sfc_drag_coeff_option,&
@@ -213,6 +217,8 @@ contains
     this%veg_class_name     = veg_class_name
     this%lat                = lat
     this%lon                = lon
+    this%terrain_slope      = terrain_slope
+    this%azimuth            = azimuth
     this%ZREF               = ZREF
 
     this%isltyp           = isltyp

--- a/src/NamelistRead.f90
+++ b/src/NamelistRead.f90
@@ -22,6 +22,7 @@ type, public :: namelist_type
   real               :: terrain_slope      ! terrain slope (°)
   real               :: azimuth            ! terrain azimuth or aspect (° clockwise from north)
   real               :: ZREF               ! measurement height for wind speed (m)
+  real               :: rain_snow_thresh   ! rain-snow temperature threshold (°C)
 
   integer            :: isltyp             ! soil type
   integer            :: nsoil              ! number of soil layers
@@ -100,6 +101,7 @@ contains
     real               :: terrain_slope
     real               :: azimuth
     real               :: ZREF               ! measurement height for wind speed (m)
+    real               :: rain_snow_thresh
 
     integer       :: isltyp
     integer       :: nsoil
@@ -147,7 +149,7 @@ contains
     namelist / timing          / dt,startdate,enddate,input_filename,output_filename
     namelist / parameters      / parameter_dir, soil_table, general_table, noahowp_table, soil_class_name, veg_class_name
     namelist / location        / lat,lon,terrain_slope,azimuth
-    namelist / forcing         / ZREF
+    namelist / forcing         / ZREF,rain_snow_thresh
     namelist / model_options   / precip_phase_option,runoff_option,drainage_option,frozen_soil_option,dynamic_vic_option,&
                                  dynamic_veg_option,snow_albedo_option,radiative_transfer_option,sfc_drag_coeff_option,&
                                  canopy_stom_resist_option,crop_model_option,snowsoil_temp_time_option,soil_temp_boundary_option,&
@@ -220,6 +222,7 @@ contains
     this%terrain_slope      = terrain_slope
     this%azimuth            = azimuth
     this%ZREF               = ZREF
+    this%rain_snow_thresh   = rain_snow_thresh
 
     this%isltyp           = isltyp
     this%nsoil            = nsoil

--- a/src/OptionsType.f90
+++ b/src/OptionsType.f90
@@ -13,6 +13,9 @@ type, public :: options_type
                         !   2 -> rain-snow air temperature threshold of 2.2°C
                         !   3 -> rain-snow air temperature threshold of 0°C
                         !   4 -> precipitation phase from weather model
+                        !   5 -> user-defined air temperature threshold
+                        !   6 -> user-defined wet bulb temperature threshold
+                        !   7 -> binary logistic regression model from Jennings et al. (2018)
   integer :: opt_run    ! runoff_option: options for runoff
                         !   1 -> TOPMODEL with groundwater (Niu et al. 2007 JGR)
                         !   2 -> TOPMODEL with an equilibrium water table (Niu et al. 2005 JGR)

--- a/src/ParametersType.f90
+++ b/src/ParametersType.f90
@@ -358,7 +358,16 @@ contains
     this%PSIWLT    = -150.0      ! originally a fixed parameter set in ENERGY()
     this%TBOT      = 263.0       ! (K) can be updated depending on option OPT_TBOT
     
-    this%rain_snow_thresh = namelist%rain_snow_thresh ! assign threshold from namelist
+    ! Assign rain-snow threshold based on option
+    IF(namelist%precip_phase_option == 2) THEN
+      this%rain_snow_thresh = this%TFRZ + 2.2
+    ELSE IF(namelist%precip_phase_option == 3) THEN
+      this%rain_snow_thresh = this%TFRZ
+    ELSE IF(namelist%precip_phase_option == 5 .or. namelist%precip_phase_option == 6)
+      this%rain_snow_thresh = this%TFRZ + namelist%rain_snow_thresh
+    ELSE 
+      rs_thresh = this%TFRZ ! set to TFRZ as a backup
+    ENDIF
     
     ! Assign initial soil moisture based on variable or uniform initial conditions
     if(namelist%initial_uniform) then

--- a/src/ParametersType.f90
+++ b/src/ParametersType.f90
@@ -141,6 +141,7 @@ type, public :: parameters_type
   real                            :: PSIWLT                    ! matric potential for wilting point (m)  (orig a fixed param.)
   real                            :: TBOT                      ! bottom condition for soil temp. (k)
   real                            :: GRAV                      ! acceleration due to gravity (m/s2)
+  real                            :: rain_snow_thresh          ! user-defined rain-snow temperature threshold (°C)
 
   contains
 
@@ -356,6 +357,8 @@ contains
     this%O2        =  0.209      ! o2 partial pressure, from O2_TABLE var (set in MPTABLE.TBL)
     this%PSIWLT    = -150.0      ! originally a fixed parameter set in ENERGY()
     this%TBOT      = 263.0       ! (K) can be updated depending on option OPT_TBOT
+    
+    this%rain_snow_thresh = namelist%rain_snow_thresh ! assign threshold from namelist
     
     ! Assign initial soil moisture based on variable or uniform initial conditions
     if(namelist%initial_uniform) then

--- a/src/ParametersType.f90
+++ b/src/ParametersType.f90
@@ -363,10 +363,10 @@ contains
       this%rain_snow_thresh = this%TFRZ + 2.2
     ELSE IF(namelist%precip_phase_option == 3) THEN
       this%rain_snow_thresh = this%TFRZ
-    ELSE IF(namelist%precip_phase_option == 5 .or. namelist%precip_phase_option == 6)
+    ELSE IF(namelist%precip_phase_option == 5 .or. namelist%precip_phase_option == 6) THEN
       this%rain_snow_thresh = this%TFRZ + namelist%rain_snow_thresh
     ELSE 
-      rs_thresh = this%TFRZ ! set to TFRZ as a backup
+      this%rain_snow_thresh = this%TFRZ ! set to TFRZ as a backup
     ENDIF
     
     ! Assign initial soil moisture based on variable or uniform initial conditions

--- a/src/ShortwaveRadiationModule.f90
+++ b/src/ShortwaveRadiationModule.f90
@@ -39,7 +39,7 @@ contains
 
     ! Compute net solar radiation
     CALL NetSolarRadiation(domain, levels, options, parameters, forcing, energy, water)
-
+   
   END SUBROUTINE ShortwaveRadiationMain
   
   !== begin NetSolarRadiation, formerly SURRAD ===========================================

--- a/src/UtilitiesModule.f90
+++ b/src/UtilitiesModule.f90
@@ -34,7 +34,7 @@ contains
     ! calculate current declination of direct solar radiation input
     call calc_declin(domain%nowdate(1:4)//"-"//domain%nowdate(5:6)//"-"//domain%nowdate(7:8)//"_"//domain%nowdate(9:10)//":"//domain%nowdate(11:12)//":00", & ! in
                      domain%lat, domain%lon, domain%terrain_slope, domain%azimuth,&                                                                           ! in
-                     energy%cosz, forcing%yearlen, forcing%julian)                                                                                            ! out
+                     energy%cosz, energy%cosz_horiz,forcing%yearlen, forcing%julian)                                                                                            ! out
     
   END SUBROUTINE UtilitiesMain
 
@@ -807,7 +807,7 @@ contains
 
   SUBROUTINE calc_declin (nowdate, &                             ! in
                           latitude, longitude, slope, azimuth, & ! in
-                          cosz, yearlen, julian)                 ! out
+                          cosz, cosz_horiz, yearlen, julian)                 ! out
   !---------------------------------------------------------------------
     IMPLICIT NONE
   !---------------------------------------------------------------------
@@ -819,6 +819,7 @@ contains
     real,              intent(in)  :: slope      ! slope (degrees)
     real,              intent(in)  :: azimuth    ! azimuth (degrees)
     real,              intent(out) :: cosz       ! cosine of solar zenith angle
+    real,              intent(out) :: cosz_horiz ! cosine of solar zenith angle for flat ground
     integer,           intent(out) :: yearlen    ! year length
     real,              intent(out) :: JULIAN     ! julian day
 
@@ -909,6 +910,15 @@ contains
     ! Compute COSZ using the dot product of the two vectors
     ! Simplified here algebraically
     COSZ = (nvx * svx) + (nvy * svy) + (nvz * svz)
+    
+    ! We also need to know the flat ground COSZ to correct incoming solar radiation
+    ! which is typically assumed to be measured/modeled for a flat surface
+    ! for a horizontal plane, nvx = 0, nvy = 0, and nvz = 1 (svx, svy, svz are as calculated previously)
+    nvx = 0.0
+    nvy = 0.0
+    nvz = 1.0
+    COSZ_HORIZ = (nvx * svx) + (nvy * svy) + (nvz * svz)
+    
     
   END SUBROUTINE calc_declin
   


### PR DESCRIPTION
This PR will merge the `snow-mods` branch into main. It includes a selection of improvements to the Noah-OWP-Modular codebase designed to better represent cold regions hydrology. These are:

1. Two additional precipitation phase partitioning methods to split precipitation into rain and snow. One is a wet bulb temperature threshold and the other is a binary logistic regression model that estimates the probability of snowfall as a function of air temperature and relative humidity. Merged to `snow-mods` in PR #51 (click for more info).
2. Routines to correct incoming solar radiation for slope and aspect. The original Noah-MP assumed a flat domain which is appropriate running at large spatial scales, but less so at the smaller scales of the National Water Model. Merged to `snow-mods` in PR #52 (click for more info).
3. A new ground surface temperature variable for passing to the Soil Freeze Thaw model. The original code switches `TG` to be snow surface temperature when snow is on the ground. A new routine adds `TGS` which is equivalent to `TG` when there is no snow or the temperature of the top soil layer when there is snow. Merged to `snow-mods` in PR #56 (click for more info).

I've tested these modifications in both standalone mode and in the Next Generation Water Resources Modeling Framework.

Closes #46
Closes #47 
Closes #53 