### PR TITLE
domain nowdate patch

### DIFF
--- a/src/DomainTypeTransfer.f90
+++ b/src/DomainTypeTransfer.f90
@@ -45,7 +45,8 @@ module DomainTypeTransfer
 
     domaingrid%zsoil(ix,iy,:) = domain%zsoil(:) 
     domaingrid%dzsnso(ix,iy,:) = domain%dzsnso(:)  
-    domaingrid%zsnso(ix,iy,:) = domain%zsnso(:)   
+    domaingrid%zsnso(ix,iy,:) = domain%zsnso(:)
+    domaingrid%nowdate = domain%nowdate   
 
   end subroutine DomainVarOutTransfer
 


### PR DESCRIPTION
PURPOSE

This PR adds the `nowdate` variable -- which is a member of `domaingrid_type` and `domain_type` -- to the `DomainVarOutTransfer` subroutine. 

Because `nowdate` is calculated/updated within the scope of `solve_noahowp` (specifically within the `UtilitiesMain` subroutine), the updated value must be included within the `DomainVarOutTransfer` subroutine so that the updated `nowdate` is available to the subsequent time step call to `read_forcing_text`. If `nowdate` is not included, the forcing file is incorrectly read-in.

ADDITIONS

`domaingrid%nowdate = domain%nowdate` was added to the `DomainVarOutTransfer` subroutine.

CHANGES

TESTING

`/test/analysis/compare_outputnc.py` was executed and grid cell (1,1) passed all tests while other grid cells did not pass all tests.

NOTES

This was a difficult bug to find. I was working on a PR for the read NetCDF file functions and could not get `/test/analysis/compare_outputnc.py` to pass tests for gric cell (1,1). I assumed that my changes related to the new PR were causing the problem. However, I found that the problem was due to my removing nowdate from the `DomainVarOutTransfer` subroutine in PR #82. 

I think the best solution would be to calculate/advance `domaingrid_type%nowdate` outside the scope of `solve_noahowp`, then transfer `nowdate` into `domain_type` prior to calling `solve_noahowp`, then don't worry about transferring `nowdate` back out to `domaingrid_type` because there is no need to do so.