### PR TITLE
Add support for NWM 3.0 baseline variables

### DIFF
--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -98,7 +98,7 @@ module bminoahowp
 
   ! Exchange items
   integer, parameter :: input_item_count = 8
-  integer, parameter :: output_item_count = 7
+  integer, parameter :: output_item_count = 23
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -163,12 +163,28 @@ contains
     integer :: bmi_status
 
     output_items(1) = 'QINSUR'     ! total liquid water input to surface rate (m/s)
-    output_items(2) = 'ETRAN'      ! transpiration rate (mm/s)
-    output_items(3) = 'QSEVA'      ! evaporation rate (m/s)
-    output_items(4) = 'EVAPOTRANS' ! evapotranspiration rate (m/s)
+    output_items(2) = 'ETRAN'      ! transpiration rate (mm)
+    output_items(3) = 'QSEVA'      ! evaporation rate (mm/s)
+    output_items(4) = 'EVAPOTRANS' ! evapotranspiration rate (mm)
     output_items(5) = 'TG'         ! surface/ground temperature (K) (becomes snow surface temperature when snow is present)
     output_items(6) = 'SNEQV'      ! snow water equivalent (mm)
     output_items(7) = 'TGS'        ! ground temperature (K) (is equal to TG when no snow and equal to bottom snow element temperature when there is snow)
+    output_items(8) = 'ACSNOM'     ! Accumulated meltwater from bottom snow layer (mm) (NWM 3.0 output variable)
+    output_items(9) = 'SNOWT_AVG'  ! Average snow temperature (K) (by layer mass) (NWM 3.0 output variable)
+    output_items(10) = 'ISNOW'     ! Number of snow layers (unitless) (NWM 3.0 output variable)
+    output_items(11) = 'QRAIN'     ! Rainfall rate on the ground (mm/s) (NWM 3.0 output variable)
+    output_items(12) = 'FSNO'      ! Snow-cover fraction on the ground (unitless fraction) (NWM 3.0 output variable)
+    output_items(13) = 'SNOWH'     ! Snow depth (m) (NWM 3.0 output variable)
+    output_items(14) = 'SNLIQ'     ! Snow layer liquid water (mm) (NWM 3.0 output variable)
+    output_items(15) = 'QSNOW'     ! Snowfall rate on the ground (mm/s) (NWM 3.0 output variable)
+    output_items(16) = 'ECAN'      ! evaporation of intercepted water (mm) (NWM 3.0 output variable)
+    output_items(17) = 'GH'        ! Heat flux into the soil (W/m-2) (NWM 3.0 output variable)
+    output_items(18) = 'TRAD'      ! Surface radiative temperature (K) (NWM 3.0 output variable)
+    output_items(19) = 'FSA'       ! Total absorbed SW radiation (W/m-2) (NWM 3.0 output variable)
+    output_items(20) = 'CMC'       ! Total canopy water (liquid + ice) (mm) (NWM 3.0 output variable)
+    output_items(21) = 'LH'        ! Total latent heat to the atmosphere (W/m-2) (NWM 3.0 output variable)
+    output_items(22) = 'FIRA'      ! Total net LW radiation to atmosphere (W/m-2) (NWM 3.0 output variable)
+    output_items(23) = 'FSH'       ! Total sensible heat to the atmosphere (W/m-2) (NWM 3.0 output variable)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -287,9 +303,14 @@ contains
 
     select case(name)
     case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! input vars
-         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS')             ! output vars
-       grid = 0
-       bmi_status = BMI_SUCCESS
+         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS',    & ! output vars
+         'ACSNOM','SNOWT_AVG','ISNOW','QRAIN','FSNO','SNOWH','QSNOW',       &
+         'ECAN','GH','TRAD','FSA','CMC','LH','FIRA','FSH')
+         grid = 0
+         bmi_status = BMI_SUCCESS
+    case('SNLIQ')
+         grid = 1
+         bmi_status = BMI_SUCCESS
     case default
        grid = -1
        bmi_status = BMI_FAILURE
@@ -306,6 +327,9 @@ contains
     select case(grid)
     case(0)
        type = "scalar"
+       bmi_status = BMI_SUCCESS
+    case(1)
+       type = "vector"
        bmi_status = BMI_SUCCESS
 !================================ IMPLEMENT WHEN noahowp DONE IN GRID ======================
 !     case(1)
@@ -327,6 +351,9 @@ contains
     select case(grid)
     case(0)
        rank = 0
+       bmi_status = BMI_SUCCESS
+    case(1)
+       rank = 1
        bmi_status = BMI_SUCCESS
 !================================ IMPLEMENT WHEN noahowp DONE IN GRID ======================
 !     case(1)
@@ -367,6 +394,9 @@ contains
     select case(grid)
     case(0)
        size = 1
+       bmi_status = BMI_SUCCESS
+    case(1)
+       size = this%model%levels%nsnow
        bmi_status = BMI_SUCCESS
 !================================ IMPLEMENT WHEN noahowp DONE IN GRID ======================
 !     case(1)
@@ -557,9 +587,13 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! input vars
-         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS')             ! output vars
+    case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! forcing vars
+       'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS', 'ACSNOM', 'SNOWT_AVG', &      ! output vars
+       'QRAIN', 'FSNO', 'SNOWH', 'SNLIQ', 'QSNOW', 'ECAN', 'GH', 'TRAD', 'FSA', 'CMC', 'LH', 'FIRA', 'FSH')
        type = "real"
+       bmi_status = BMI_SUCCESS
+    case('ISNOW')
+       type = "integer"
        bmi_status = BMI_SUCCESS
     case default
        type = "-"
@@ -578,10 +612,10 @@ contains
     case("SFCPRS")
        units = "Pa"
        bmi_status = BMI_SUCCESS
-    case("SFCTMP", "TG", "TGS")
+    case("SFCTMP", "TG", "TGS","SNOWT_AVG","TRAD")
        units = "K"
        bmi_status = BMI_SUCCESS
-    case("SOLDN", "LWDN")
+    case("SOLDN", "LWDN", "GH", "FSA", "LH", "FIRA", "FSH")
        units = "W/m2"
        bmi_status = BMI_SUCCESS
     case("UU", "VV")
@@ -590,19 +624,26 @@ contains
     case("Q2")
        units = "kg/kg"
        bmi_status = BMI_SUCCESS
-    case("QINSUR", "QSEVA", "EVAPOTRANS")
+    case("QINSUR")
        units = "m/s"
        bmi_status = BMI_SUCCESS
-    case("PRCPNONC", "ETRAN")
+    case("PRCPNONC", "QRAIN", "QSEVA", "QSNOW")
        units = "mm/s"
        bmi_status = BMI_SUCCESS
-    case("SNEQV")
+    case("SNEQV", "ACSNOW", "EVAPOTRANS", "SNLIQ", "ECAN", "ETRAN", "CMC")
        units = "mm"
+       bmi_status = BMI_SUCCESS
+    case("FSNO","ISNOW")
+       units = "unitless"
+       bmi_status = BMI_SUCCESS
+    case("SNOWH")
+       units = "m"
        bmi_status = BMI_SUCCESS
     case default
        units = "-"
        bmi_status = BMI_FAILURE
     end select
+
   end function noahowp_var_units
 
   ! Memory use per array element.
@@ -612,56 +653,109 @@ contains
     integer, intent(out) :: size
     integer :: bmi_status
 
+    associate(forcing => this%model%forcing, &
+              water   => this%model%water,   &
+              energy  => this%model%energy)
+
     select case(name)
     case("SFCPRS")
-       size = sizeof(this%model%forcing%sfcprs)  ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%sfcprs)  ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("SFCTMP")
-       size = sizeof(this%model%forcing%sfctmp)             ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%sfctmp)             ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("SOLDN")
-       size = sizeof(this%model%forcing%soldn)                ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%soldn)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("LWDN")
-       size = sizeof(this%model%forcing%lwdn)                ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%lwdn)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("UU")
-       size = sizeof(this%model%forcing%uu)                ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%uu)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("VV")
-       size = sizeof(this%model%forcing%vv)                ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%vv)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("Q2")
-       size = sizeof(this%model%forcing%q2)                ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%q2)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("PRCPNONC")
-       size = sizeof(this%model%forcing%prcpnonc)                ! 'sizeof' in gcc & ifort
+       size = sizeof(forcing%prcpnonc)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("QINSUR")
-       size = sizeof(this%model%water%qinsur)                ! 'sizeof' in gcc & ifort
+       size = sizeof(water%qinsur)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("ETRAN")
-       size = sizeof(this%model%water%etran)                ! 'sizeof' in gcc & ifort
+       size = sizeof(water%etran)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("QSEVA")
-       size = sizeof(this%model%water%qseva)                ! 'sizeof' in gcc & ifort
+       size = sizeof(water%qseva)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("EVAPOTRANS")
-       size = sizeof(this%model%water%evapotrans)            ! 'sizeof' in gcc & ifort
+       size = sizeof(water%evapotrans)            ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("TG")
-       size = sizeof(this%model%energy%tg)            ! 'sizeof' in gcc & ifort
+       size = sizeof(energy%tg)            ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("SNEQV")
-       size = sizeof(this%model%water%sneqv)            ! 'sizeof' in gcc & ifort
+       size = sizeof(water%sneqv)            ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case("TGS")
-       size = sizeof(this%model%energy%tgs)            ! 'sizeof' in gcc & ifort
+       size = sizeof(energy%tgs)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("ACSNOM")
+       size = sizeof(water%ACSNOM)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("SNOWT_AVG")
+       size = sizeof(energy%SNOWT_AVG)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("ISNOW")
+       size = sizeof(water%ISNOW)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("QRAIN")
+       size = sizeof(water%QRAIN)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("FSNO")
+       size = sizeof(water%FSNO)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("SNOWH")
+       size = sizeof(water%SNOWH)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("QSNOW")
+       size = sizeof(water%QSNOW)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("ECAN")
+       size = sizeof(water%ECAN)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("GH")
+       size = sizeof(energy%GH)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("TRAD")
+       size = sizeof(energy%TRAD)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("FSA")
+       size = sizeof(energy%FSA)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("CMC")
+       size = sizeof(water%CMC)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("LH")
+       size = sizeof(energy%LH)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("FIRA")
+       size = sizeof(energy%FIRA)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("FSH")
+       size = sizeof(energy%FSH)            ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case("SNLIQ")
+       size = sizeof(water%SNLIQ(1))            ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case default
        size = -1
        bmi_status = BMI_FAILURE
     end select
+    end associate
   end function noahowp_var_itemsize
 
   ! The size of the given variable.
@@ -676,7 +770,10 @@ contains
     s2 = this%get_grid_size(grid, grid_size)
     s3 = this%get_var_itemsize(name, item_size)
 
-    if ((s1 == BMI_SUCCESS).and.(s2 == BMI_SUCCESS).and.(s3 == BMI_SUCCESS)) then
+    if (grid .eq. 0) then
+       nbytes = item_size
+       bmi_status = BMI_SUCCESS
+    else if ((s1 == BMI_SUCCESS).and.(s2 == BMI_SUCCESS).and.(s3 == BMI_SUCCESS)) then
        nbytes = item_size * grid_size
        bmi_status = BMI_SUCCESS
     else
@@ -711,6 +808,9 @@ contains
 !     case("model__identification_number")
 !        dest = [this%model%id]
 !        bmi_status = BMI_SUCCESS
+    case("ISNOW")
+       dest(:) = this%model%water%ISNOW
+       bmi_status = BMI_SUCCESS
     case default
        dest(:) = -1
        bmi_status = BMI_FAILURE
@@ -724,56 +824,107 @@ contains
     real, intent(inout) :: dest(:)
     integer :: bmi_status
 
+    associate(forcing => this%model%forcing, &
+              water   => this%model%water,   &
+              energy  => this%model%energy,  &
+              domain  => this%model%domain)
+
     select case(name)
     case("SFCPRS")
-       dest = [this%model%forcing%sfcprs]
+       dest = [forcing%sfcprs]
        bmi_status = BMI_SUCCESS
     case("SFCTMP")
-       dest = [this%model%forcing%sfctmp]
+       dest = [forcing%sfctmp]
        bmi_status = BMI_SUCCESS
     case("SOLDN")
-       dest = [this%model%forcing%soldn]
+       dest = [forcing%soldn]
        bmi_status = BMI_SUCCESS
     case("LWDN")
-       dest = [this%model%forcing%lwdn]
+       dest = [forcing%lwdn]
        bmi_status = BMI_SUCCESS
     case("UU")
-       dest = [this%model%forcing%uu]
+       dest = [forcing%uu]
        bmi_status = BMI_SUCCESS
     case("VV")
-       dest = [this%model%forcing%vv]
+       dest = [forcing%vv]
        bmi_status = BMI_SUCCESS
     case("Q2")
-       dest = [this%model%forcing%q2]
+       dest = [forcing%q2]
        bmi_status = BMI_SUCCESS
     case("PRCPNONC")
-       dest = [this%model%forcing%prcpnonc]
+       dest = [forcing%prcpnonc]
        bmi_status = BMI_SUCCESS
     case("QINSUR")
-       dest = [this%model%water%qinsur]
+       dest = [water%qinsur]
        bmi_status = BMI_SUCCESS
     case("ETRAN")
-       dest = [this%model%water%etran]
+       dest = [water%etran]
        bmi_status = BMI_SUCCESS
     case("QSEVA")
-       dest = [this%model%water%qseva]
+       dest = [water%qseva]
        bmi_status = BMI_SUCCESS
     case("EVAPOTRANS")
-       dest = [this%model%water%evapotrans]
+       dest = [water%evapotrans]
        bmi_status = BMI_SUCCESS
     case("TG")
-       dest = [this%model%energy%tg]
+       dest = [energy%tg]
        bmi_status = BMI_SUCCESS
     case("SNEQV")
-       dest = [this%model%water%sneqv]
+       dest = [water%sneqv]
        bmi_status = BMI_SUCCESS
     case("TGS")
-       dest = [this%model%energy%tgs]
+       dest = [energy%tgs]
+       bmi_status = BMI_SUCCESS
+    case("ACSNOM")
+       dest = [water%ACSNOM]
+       bmi_status = BMI_SUCCESS
+    case("SNOWT_AVG")
+       dest = [energy%SNOWT_AVG]
+       bmi_status = BMI_SUCCESS
+    case("QRAIN")
+       dest = [water%QRAIN]
+       bmi_status = BMI_SUCCESS
+    case("FSNO")
+       dest = [water%FSNO]
+       bmi_status = BMI_SUCCESS
+    case("SNOWH")
+       dest = [water%SNOWH]
+       bmi_status = BMI_SUCCESS
+    case("SNLIQ")
+       dest = water%SNLIQ
+       bmi_status = BMI_SUCCESS
+    case("QSNOW")
+       dest = [water%QSNOW]
+       bmi_status = BMI_SUCCESS
+    case("ECAN")
+       dest = [water%ECAN*domain%DT]
+       bmi_status = BMI_SUCCESS
+    case("GH")
+       dest = [energy%GH]
+       bmi_status = BMI_SUCCESS
+    case("TRAD")
+       dest = [energy%TRAD]
+       bmi_status = BMI_SUCCESS
+    case("FSA")
+       dest = [energy%FSA]
+       bmi_status = BMI_SUCCESS
+    case("CMC")
+       dest = [water%CMC]
+       bmi_status = BMI_SUCCESS
+    case("LH")
+       dest = [energy%LH]
+       bmi_status = BMI_SUCCESS
+    case("FIRA")
+       dest = [energy%FIRA]
+       bmi_status = BMI_SUCCESS
+    case("FSH")
+       dest = [energy%FSH]
        bmi_status = BMI_SUCCESS
     case default
        dest(:) = -1.0
        bmi_status = BMI_FAILURE
     end select
+    end associate
     ! NOTE, if vars are gridded, then use:
     ! dest = reshape(this%model%temperature, [this%model%n_x*this%model%n_y]) 
   end function noahowp_get_float

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -630,7 +630,7 @@ contains
     case("PRCPNONC", "QRAIN", "QSEVA", "QSNOW")
        units = "mm/s"
        bmi_status = BMI_SUCCESS
-    case("SNEQV", "ACSNOW", "EVAPOTRANS", "SNLIQ", "ECAN", "ETRAN", "CMC")
+    case("SNEQV", "ACSNOM", "EVAPOTRANS", "SNLIQ", "ECAN", "ETRAN", "CMC")
        units = "mm"
        bmi_status = BMI_SUCCESS
     case("FSNO","ISNOW")
@@ -823,6 +823,8 @@ contains
     character (len=*), intent(in) :: name
     real, intent(inout) :: dest(:)
     integer :: bmi_status
+    real    :: mm2m = 0.001       ! unit conversion mm to m     
+    real    :: m2mm = 1000.       ! unit conversion m to mm
 
     associate(forcing => this%model%forcing, &
               water   => this%model%water,   &
@@ -858,13 +860,13 @@ contains
        dest = [water%qinsur]
        bmi_status = BMI_SUCCESS
     case("ETRAN")
-       dest = [water%etran]
+       dest = [water%etran*domain%DT]
        bmi_status = BMI_SUCCESS
     case("QSEVA")
-       dest = [water%qseva]
+       dest = [water%qseva*m2mm]
        bmi_status = BMI_SUCCESS
     case("EVAPOTRANS")
-       dest = [water%evapotrans]
+       dest = [water%evapotrans*domain%DT*mm2m]
        bmi_status = BMI_SUCCESS
     case("TG")
        dest = [energy%tg]
@@ -1079,6 +1081,8 @@ contains
     character (len=*), intent(in) :: name
     real, intent(in) :: src(:)
     integer :: bmi_status
+    real    :: mm2m = 0.001       ! unit conversion mm to m     
+    real    :: m2mm = 1000.       ! unit conversion m to mm
 
     select case(name)
     case("SFCPRS")
@@ -1109,13 +1113,13 @@ contains
        this%model%water%qinsur = src(1)
        bmi_status = BMI_SUCCESS
     case("ETRAN")
-       this%model%water%etran = src(1)
+       this%model%water%etran = src(1) / this%model%domain%DT
        bmi_status = BMI_SUCCESS
     case("QSEVA")
-       this%model%water%qseva = src(1)
+       this%model%water%qseva = src(1) * mm2m 
        bmi_status = BMI_SUCCESS
     case("EVAPOTRANS")
-       this%model%water%evapotrans = src(1)
+       this%model%water%evapotrans = src(1) * m2mm / this%model%domain%DT
        bmi_status = BMI_SUCCESS
     case("TG")
        this%model%energy%tg = src(1)

--- a/src/EnergyModule.f90
+++ b/src/EnergyModule.f90
@@ -262,6 +262,7 @@ contains
       energy%FSH   = parameters%FVEG * energy%SHG       + (1.0 - parameters%FVEG) * energy%SHB       + energy%SHC
       energy%FGEV  = parameters%FVEG * energy%EVG       + (1.0 - parameters%FVEG) * energy%EVB
       energy%SSOIL = parameters%FVEG * energy%GHV       + (1.0 - parameters%FVEG) * energy%GHB
+      energy%GH    = parameters%FVEG * energy%GHV       + (1.0 - parameters%FVEG) * energy%GHB ! FVEG = 1. Hence, this is a weighted average
       energy%FCEV  = energy%EVC
       energy%FCTR  = energy%TR
       energy%PAH   = parameters%FVEG * energy%PAHG      + (1.0 - parameters%FVEG) * energy%PAHB   + energy%PAHV

--- a/src/EnergyType.f90
+++ b/src/EnergyType.f90
@@ -20,7 +20,8 @@ type, public :: energy_type
   real,    allocatable, dimension(:) :: DF     ! snow and soil layer thermal conductivity [w/m/k]
   real,    allocatable, dimension(:) :: HCPCT  ! snow and soil layer heat capacity [j/m3/k]
   real,    allocatable, dimension(:) :: FACT   ! temporary variable used in phase change [s/j/m2/k]
-  
+  real                               :: SNOWT_AVG  ! average snow temperature [k] (by layer mass) (a NWM 3.0 output variable)
+
   ! Heat advected by precipitation
   real    :: PAHV                              ! precipitation advected heat - vegetation net (W/m2)
   real    :: PAHG                              ! precipitation advected heat - under canopy net (W/m2)
@@ -328,7 +329,7 @@ contains
     this%TGS       = huge(1.0)    
     
     this%ICE       = huge(1)    
-    
+    this%SNOWT_AVG = huge(1.0)
     
     
   end subroutine InitDefault

--- a/src/EtFluxModule.f90
+++ b/src/EtFluxModule.f90
@@ -705,7 +705,7 @@ contains
         energy%Q2B   = QSFC
       ELSE
         energy%T2MB  = TGB - energy%SHB/(RHOAIR*CPAIR) * 1./energy%EHB2
-        energy%Q2B   = QSFC - energy%EVB/(energy%LATHEA*RHOAIR)*(1./CQ2B + energy%RSURF)
+        energy%Q2B   = QSFC - energy%EVB/(energy%LATHEAG*RHOAIR)*(1./CQ2B + energy%RSURF)
       ENDIF
       IF (parameters%urban_flag) energy%Q2B = QSFC
     END IF

--- a/src/SnowWaterModule.f90
+++ b/src/SnowWaterModule.f90
@@ -93,6 +93,14 @@ contains
        domain%DZSNSO(IZ) = -domain%DZSNSO(IZ)
    END DO
 
+   ! NWM3.0 parameter
+   if (sum(water%SNICE(-levels%nsnow+1:0) + water%SNLIQ(-levels%nsnow+1:0)).gt.0.) then
+      energy%SNOWT_AVG = SUM(energy%STC(-levels%nsnow+1:0)*(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))) / &
+                         SUM(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))
+   else
+      energy%SNOWT_AVG = huge(1.)
+   end if
+
   END SUBROUTINE SnowWater
 
 end module SnowWaterModule

--- a/src/SnowWaterModule.f90
+++ b/src/SnowWaterModule.f90
@@ -30,9 +30,11 @@ contains
 ! ------------------------ local variables ---------------------------
   INTEGER :: IZ,i
   REAL    :: BDSNOW  !bulk density of snow (kg/m3)
+  REAL    :: realMissing
 ! ----------------------------------------------------------------------
 
 ! initialization
+   realMissing    = -999999.0
    water%SNOFLOW  = 0.0
    water%PONDING1 = 0.0
    water%PONDING2 = 0.0
@@ -98,7 +100,7 @@ contains
       energy%SNOWT_AVG = SUM(energy%STC(-levels%nsnow+1:0)*(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))) / &
                          SUM(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))
    else
-      energy%SNOWT_AVG = huge(1.)
+      energy%SNOWT_AVG = realMissing
    end if
 
   END SUBROUTINE SnowWater

--- a/src/WaterModule.f90
+++ b/src/WaterModule.f90
@@ -108,6 +108,8 @@ contains
     ! convert units (mm/s -> m/s)
     !PONDING: melting water from snow when there is no layer
     water%QINSUR = (water%PONDING+water%PONDING1+water%PONDING2)/domain%DT * 0.001
+    water%ACSNOM = (water%PONDING+water%PONDING1+water%PONDING2+(water%QSNBOT*domain%DT))
+
     !    QINSUR = PONDING/DT * 0.001
     IF(water%ISNOW == 0) THEN
        water%QINSUR = water%QINSUR+(water%QSNBOT + water%QSDEW + water%QRAIN) * 0.001

--- a/src/WaterType.f90
+++ b/src/WaterType.f90
@@ -58,6 +58,7 @@ type, public :: water_type
   real                            :: WSLAKE      ! water storage in lake (can be -) (mm)
   real                            :: runsrf_dt   ! temporal time step for surface runoff calculations
   real                            :: ASAT        ! accumulated saturation in VIC runoff scheme
+  real                            :: ACSNOM      ! Accumulated meltwater from bottom snow layer [mm] (NWM 3.0)
   
   integer                         :: ISNOW       ! actual no. of snow layers 
   real, allocatable, dimension(:) :: smc         ! total soil water content [m3/m3]
@@ -180,6 +181,7 @@ contains
     this%ASAT     = huge(1.0)
     this%ISNOW    = huge(1)
     this%FSNO     = huge(1.0)
+    this%ACSNOM   = huge(1.0)
 
   end subroutine InitDefault
 

--- a/test/noahowp_driver_test.f90
+++ b/test/noahowp_driver_test.f90
@@ -31,6 +31,7 @@ program noahmp_driver_test
     integer                                           :: count            ! var counts
     character (len = BMI_MAX_VAR_NAME), pointer       :: names_inputs(:)  ! var names
     character (len = BMI_MAX_VAR_NAME), pointer       :: names_outputs(:) ! var names
+    character (len = BMI_MAX_VAR_NAME)                :: name             ! var name
     integer                                           :: n_inputs         ! n input vars
     integer                                           :: n_outputs        ! n output vars
     integer                                           :: iBMI             ! loop counter
@@ -44,8 +45,10 @@ program noahmp_driver_test
     double precision                                  :: end_time         ! time of last model time step
     double precision                                  :: current_time     ! current model time
     character (len = 1)                               :: ts_units         ! timestep units
-    real, allocatable, target                         :: var_value_get(:) ! value of a variable
-    real, allocatable                                 :: var_value_set(:) ! value of a variable
+    real, allocatable, target                         :: var_value_get_real(:) ! value of a variable
+    real, allocatable                                 :: var_value_set_real(:) ! value of a variable
+    integer, allocatable, target                      :: var_value_get_int(:) ! value of a variable
+    integer, allocatable                              :: var_value_set_int(:) ! value of a variable
     integer                                           :: grid_int         ! grid value
     character (len = 20)                              :: grid_type        ! name of grid type
     integer                                           :: grid_rank        ! rank of grid
@@ -58,9 +61,10 @@ program noahmp_driver_test
     double precision, dimension(1)                    :: grid_y           ! Y coordinate of grid nodes (change dims if multiple nodes)
     double precision, dimension(1)                    :: grid_z           ! Y coordinate of grid nodes (change dims if multiple nodes)
     
-    real, pointer                                 :: var_value_get_ptr(:) ! value of a variable for get_value_ptr
+    real, pointer                                     :: var_value_get_real_ptr(:) ! value of a variable for get_value_ptr
+    integer, pointer                                  :: var_value_get_int_ptr(:) ! value of a variable for get_value_ptr
 
-    integer, dimension(3)                             :: grid_indices       ! grid indices (change dims as needed)
+    integer, allocatable, dimension(:)                :: grid_indices       ! grid indices (change dims as needed)
   !---------------------------------------------------------------------
   !  Initialize
   !---------------------------------------------------------------------
@@ -99,26 +103,23 @@ program noahmp_driver_test
     
     ! Get other variable info
     do j = 1, count
+      name = ''
       if(j <= n_inputs) then
-        status = m%get_var_type(trim(names_inputs(j)), var_type)
-        status = m%get_var_units(trim(names_inputs(j)), var_units)
-        status = m%get_var_itemsize(trim(names_inputs(j)), var_itemsize)
-        status = m%get_var_nbytes(trim(names_inputs(j)), var_nbytes)
-        print*, "The variable ", trim(names_inputs(j))
+        name = names_inputs(j)
       else
-        status = m%get_var_type(trim(names_outputs(j - n_inputs)), var_type)
-        status = m%get_var_units(trim(names_outputs(j - n_inputs)), var_units)
-        status = m%get_var_itemsize(trim(names_outputs(j - n_inputs)), var_itemsize)
-        status = m%get_var_nbytes(trim(names_outputs(j - n_inputs)), var_nbytes)
-        print*, "The variable ", trim(names_outputs(j - n_inputs))
+        name = names_outputs(j - n_inputs)
       end if
+      status = m%get_var_type(trim(name), var_type)
+      status = m%get_var_units(trim(name), var_units)
+      status = m%get_var_itemsize(trim(name), var_itemsize)
+      status = m%get_var_nbytes(trim(name), var_nbytes)
+      print*, "The variable ", trim(name)
       print*, "    has a type of ", var_type
       print*, "    units of ", var_units
       print*, "    a size of ", var_itemsize
       print*, "    and total n bytes of ", var_nbytes
     end do
 
-    
   !---------------------------------------------------------------------
   ! Get time information
   !---------------------------------------------------------------------
@@ -166,52 +167,79 @@ program noahmp_driver_test
   !---------------------------------------------------------------------
   ! Test the get/set_value functionality with BMI
   !---------------------------------------------------------------------
-    allocate(var_value_get(1))
-    allocate(var_value_set(1))
-    var_value_set = 999.9999
-    
-    ! Loop through the input vars
-    do iBMI = 1, n_inputs
-      status = m%get_value(trim(names_inputs(iBMI)), var_value_get)
-      print*, trim(names_inputs(iBMI)), " from get_value = ", var_value_get
-      print*, "    our replacement value = ", var_value_set
-      status = m%set_value(trim(names_inputs(iBMI)), var_value_set)
-      status = m%get_value(trim(names_inputs(iBMI)), var_value_get)
-      print*, "    and the new value of ", trim(names_inputs(iBMI)), " = ", var_value_get
-    end do
-    
-    ! Loop through the output vars
-    do iBMI = 1, n_outputs
-      status = m%get_value(trim(names_outputs(iBMI)), var_value_get)
-      print*, trim(names_outputs(iBMI)), " from get_value = ", var_value_get
-      print*, "    our replacement value = ", var_value_set
-      status = m%set_value(trim(names_outputs(iBMI)), var_value_set)
-      status = m%get_value(trim(names_outputs(iBMI)), var_value_get)
-      print*, "    and the new value of ", trim(names_outputs(iBMI)), " = ", var_value_get
+    ! Loop through the input and output vars
+    do iBMI = 1, count
+      name = ''
+      if(iBMI <= n_inputs) then
+        name = names_inputs(iBMI)
+      else
+        name = names_outputs(iBMI - n_inputs)
+      end if
+      status = m%get_var_type(trim(name),var_type)
+      status = m%get_var_grid(trim(name),grid_int)
+      status = m%get_grid_size(grid_int,grid_size)
+      if(var_type.eq.'integer') then
+        if(allocated(var_value_get_int)) deallocate(var_value_get_int)
+        if(allocated(var_value_set_int)) deallocate(var_value_set_int)
+        allocate(var_value_get_int(grid_size))
+        allocate(var_value_set_int(grid_size))
+        var_value_set_int = 999
+        status = m%get_value(trim(name), var_value_get_int)
+        print*, trim(name), " from get_value = ", var_value_get_int
+        print*, "    our replacement value = ", var_value_set_int
+        status = m%set_value(trim(name), var_value_set_int)
+        status = m%get_value(trim(name), var_value_get_int)
+        print*, "    and the new value of ", trim(name), " = ", var_value_get_int
+      else if (var_type.eq.'real') then
+        if(allocated(var_value_get_real)) deallocate(var_value_get_real)
+        if(allocated(var_value_set_real)) deallocate(var_value_set_real)
+        allocate(var_value_get_real(grid_size))
+        allocate(var_value_set_real(grid_size))
+        var_value_set_real = 999
+        status = m%get_value(trim(name), var_value_get_real)
+        print*, trim(name), " from get_value = ", var_value_get_real
+        print*, "    our replacement value = ", var_value_set_real
+        status = m%set_value(trim(name), var_value_set_real)
+        status = m%get_value(trim(name), var_value_get_real)
+        print*, "    and the new value of ", trim(name), " = ", var_value_get_real
+      end if
     end do
     
   !---------------------------------------------------------------------
   ! Test the get_value_ptr functionality with BMI
   !---------------------------------------------------------------------
-    var_value_get_ptr => var_value_get
     ! test the get value pointer  functions
-    ! Loop through the input vars
-    do iBMI = 1, n_inputs
-      status = m%get_value_ptr(trim(names_inputs(iBMI)), var_value_get_ptr)
-      if ( status .eq. BMI_FAILURE ) then
-        print*, trim(names_inputs(iBMI)), " from get_value_ptr returned BMI_FAILURE --- test passed" 
+    ! Loop through the input and output vars
+    do iBMI = 1, count
+      name = ''
+      if(iBMI <= n_inputs) then
+        name = names_inputs(iBMI)
       else
-        print*, trim(names_inputs(iBMI)), " from get_value_ptr returned ", status, " TEST FAILED!" 
+        name = names_outputs(iBMI - n_inputs)
       end if
-    end do
-
-    ! Loop through the output vars
-    do iBMI = 1, n_outputs
-      status = m%get_value_ptr(trim(names_outputs(iBMI)), var_value_get_ptr)
-      if ( status .eq. BMI_FAILURE ) then
-        print*, trim(names_outputs(iBMI)), " from get_value_ptr returned BMI_FAILURE --- test passed" 
-      else
-        print*, trim(names_outputs(iBMI)), " from get_value_ptr returned ", status, " TEST FAILED!" 
+      status = m%get_var_type(trim(name),var_type)
+      status = m%get_var_grid(trim(name),grid_int)
+      status = m%get_grid_size(grid_int,grid_size)
+      if(var_type.eq.'integer') then
+        if(allocated(var_value_get_int)) deallocate(var_value_get_int)
+        allocate(var_value_get_int(grid_size))
+        var_value_get_int_ptr => var_value_get_int
+        status = m%get_value_ptr(trim(name), var_value_get_int_ptr)
+        if ( status .eq. BMI_FAILURE ) then
+          print*, trim(name), " from get_value_ptr returned BMI_FAILURE --- test passed" 
+        else
+          print*, trim(name), " from get_value_ptr returned ", status, " TEST FAILED!" 
+        end if
+      else if (var_type.eq.'real') then
+        if(allocated(var_value_get_real)) deallocate(var_value_get_real)
+        allocate(var_value_get_real(grid_size))
+        var_value_get_real_ptr => var_value_get_real
+        status = m%get_value_ptr(trim(name), var_value_get_real_ptr)
+        if ( status .eq. BMI_FAILURE ) then
+          print*, trim(name), " from get_value_ptr returned BMI_FAILURE --- test passed" 
+        else
+          print*, trim(name), " from get_value_ptr returned ", status, " TEST FAILED!" 
+        end if
       end if
     end do
 
@@ -219,40 +247,55 @@ program noahmp_driver_test
   ! Test the get_value_at_indices functionality with BMI
   !---------------------------------------------------------------------
     ! Loop through the input vars
-    do iBMI = 1, n_inputs
-      status = m%get_value_at_indices(trim(names_inputs(iBMI)), var_value_get, grid_indices)
-      if ( status .eq. BMI_FAILURE ) then
-        print*, trim(names_inputs(iBMI)), " from get_value_at_indices returned BMI_FAILURE --- test passed" 
+    do iBMI = 1, count
+      name = ''
+      if(iBMI <= n_inputs) then
+        name = names_inputs(iBMI)
       else
-        print*, trim(names_inputs(iBMI)), " from get_value_at_indices returned ", status, " TEST FAILED!" 
+        name = names_outputs(iBMI - n_inputs)
       end if
-      status = m%set_value_at_indices(trim(names_inputs(iBMI)), grid_indices, var_value_set)
-      if ( status .eq. BMI_FAILURE ) then
-        print*, trim(names_inputs(iBMI)), " from set_value_at_indices returned BMI_FAILURE --- test passed" 
-      else
-        print*, trim(names_inputs(iBMI)), " from set_value_at_indices returned ", status, " TEST FAILED!" 
-      end if
-    end do
-    
-    ! Loop through the output vars
-    do iBMI = 1, n_outputs
-      status = m%get_value_at_indices(trim(names_outputs(iBMI)), var_value_get, grid_indices)
-      if ( status .eq. BMI_FAILURE ) then
-        print*, trim(names_outputs(iBMI)), " from get_value_at_indices returned BMI_FAILURE --- test passed" 
-      else
-        print*, trim(names_outputs(iBMI)), " from get_value_at_indices returned ", status, " TEST FAILED!" 
-      end if
-      status = m%set_value_at_indices(trim(names_outputs(iBMI)), grid_indices, var_value_set)
-      if ( status .eq. BMI_FAILURE ) then
-        print*, trim(names_outputs(iBMI)), " from set_value_at_indices returned BMI_FAILURE --- test passed" 
-      else
-        print*, trim(names_outputs(iBMI)), " from set_value_at_indices returned ", status, " TEST FAILED!" 
+      status = m%get_var_type(trim(name),var_type)
+      status = m%get_var_grid(trim(name),grid_int)
+      status = m%get_grid_size(grid_int,grid_size)
+      status = m%get_grid_rank(grid_int, grid_rank)
+      if(allocated(grid_indices)) deallocate(grid_indices)
+      allocate(grid_indices(grid_rank))
+      grid_indices = 1
+      if(var_type.eq.'integer') then
+        status = m%get_value_at_indices(trim(name), var_value_get_int, grid_indices)
+        if ( status .eq. BMI_FAILURE ) then
+          print*, trim(name), " from get_value_at_indices returned BMI_FAILURE --- test passed" 
+        else
+          print*, trim(name), " from get_value_at_indices returned ", status, " TEST FAILED!" 
+        end if
+        status = m%set_value_at_indices(trim(name), grid_indices, var_value_set_int)
+        if ( status .eq. BMI_FAILURE ) then
+          print*, trim(name), " from set_value_at_indices returned BMI_FAILURE --- test passed" 
+        else
+          print*, trim(name), " from set_value_at_indices returned ", status, " TEST FAILED!" 
+        end if
+      else if (var_type.eq.'real') then 
+        status = m%get_value_at_indices(trim(name), var_value_get_real, grid_indices)
+        if ( status .eq. BMI_FAILURE ) then
+          print*, trim(name), " from get_value_at_indices returned BMI_FAILURE --- test passed" 
+        else
+          print*, trim(name), " from get_value_at_indices returned ", status, " TEST FAILED!" 
+        end if
+        status = m%set_value_at_indices(trim(name), grid_indices, var_value_set_real)
+        if ( status .eq. BMI_FAILURE ) then
+          print*, trim(name), " from set_value_at_indices returned BMI_FAILURE --- test passed" 
+        else
+          print*, trim(name), " from set_value_at_indices returned ", status, " TEST FAILED!" 
+        end if
       end if
     end do
 
-    nullify( var_value_get_ptr )
-    deallocate(var_value_get)
-    deallocate(var_value_set)
+    nullify( var_value_get_real_ptr )
+    nullify( var_value_get_int_ptr )
+    deallocate(var_value_get_real)
+    deallocate(var_value_set_real)
+    deallocate(var_value_get_int)
+    deallocate(var_value_set_int)
 
   !---------------------------------------------------------------------
   ! Test the grid info functionality with BMI


### PR DESCRIPTION
# Purpose

This PR adds support for a subset of NWM 3.0 variables that will be simulated by the non-gridded version of Noah-OM.

# Additions

The following variables were added as output variables and exposed via the Noah-OM BMI:

- `ACSNOM`
- `SNOWT_AVG`
- `ISNOW`
- `QRAIN`
- `FSNO`
- `SNOWH`
- `SNLIQ`
- `QSNOW`
- `ACCECAN` (as `ECAN * DT`)
- `GH`
- `TRAD`
- `FSA`
- `CANWAT` (as `CMC`)
- `LH`
- `FIRA`
- `HFX` (as `FSH`)

The variable `ACSNOM` was added to the `water_type` derived data type and an additional line of code was added to `WaterModule` to calculate ([following NWM 3.0](https://github.com/NCAR/wrf_hydro_nwm_public/blob/5d9e489fed01ed7cbd6b5680616ee37812a7137a/src/Land_models/NoahMP/phys/module_sf_noahmpdrv.F#L1401)) `ACSNOM` per time step as:

`water%ACSNOM = (water%PONDING+water%PONDING1+water%PONDING2+(water%QSNBOT*domain%DT))`

The variable `SNOWT_AVG` was added to the `energy_type` derived data type and code was added to the end of `SnowWaterModule` to calculate ([following NWM 3.0](https://github.com/NCAR/wrf_hydro_nwm_public/blob/5d9e489fed01ed7cbd6b5680616ee37812a7137a/src/Land_models/NoahMP/phys/module_sf_noahmpdrv.F#L1382)) `SNOWT_AVG` per time step as:

```
   if (sum(water%SNICE(-levels%nsnow+1:0) + water%SNLIQ(-levels%nsnow+1:0)).gt.0.) then
      energy%SNOWT_AVG = SUM(energy%STC(-levels%nsnow+1:0)*(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))) / &
                         SUM(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))
   else
      energy%SNOWT_AVG = huge(1.)
   end if
```

# Changes

The variables `QSEVA`,  `ETRAN`, and `EVAPOTRANS` were already in `output_items` in `/bmi/bmi_noahowp.f90` but did not have the same units as the corresponding variable in NWM 3.0. This PR modified these variables' listings in `noahowp_var_units`, `noahowp_get_float`, and `noahowp_set_float` such that the BMI-user will get/set these variables using NWM 3.0 variable units. This PR does *not* change the units of these variables as implemented within the rest of the Noah-OM code base.

(`m2mm` = unit conversion factor = 1000.)
(`mm2m` = unit conversion factor = 0.001)

- `QSEVA`
  - `noahowp_var_units` gives `mm/s`
  - `noahowp_get_float` gives `[water%qseva*m2mm]`
  - `noahowp_set_float` gives `this%model%water%qseva = src(1) * mm2m` where `src(1)` is value to set

- `ETRAN`
  - `noahowp_var_units` gives `mm`
  - `noahowp_get_float` gives `[water%etran*domain%DT]`
  - `noahowp_set_float` gives `src(1) / this%model%domain%DT` where `src(1)` is value to set

- `EVAPOTRANS`
  - `noahowp_var_units` gives `mm`
  - `noahowp_get_float` gives `[water%evapotrans*domain%DT*mm2m]`
  - `noahowp_set_float` gives `src(1) * m2mm / this%model%domain%DT` where `src(1)` is value to set

# Testing

`/test/noahowp_driver_test.f90` (the unit test) was updated to support the newly added variables and types. The unit tests were then re-executed, which gave [this result.](https://github.com/NOAA-OWP/noah-owp-modular/files/13243604/unit_test_results.txt)

# Notes

`SNLIQ` was the only non-scalar variable added by this PR. This PR adds a new grid identifier (grid id = 1 and type vector) and `SNLIQ` was associated with this new grid identifier. All other variables are associated with the existing grid identifier (grid id = 0 and type scalar).
