### PR TITLE
Patch SNOWT_AVG and ACSNOM

### DIFF
--- a/src/EnergyType.f90
+++ b/src/EnergyType.f90
@@ -336,7 +336,8 @@ module EnergyType
   
       this%LH        = huge(1.0)    
       this%TGS       = huge(1.0)    
-      this%ICE       = huge(1)    
+      this%ICE       = huge(1)   
+      this%SNOWT_AVG = huge(1.0) 
       
       this%IMELT(:)  = huge(1)
       this%STC(:)    = huge(1.0)
@@ -384,6 +385,7 @@ module EnergyType
       integer,               intent(in)    :: ix
       integer,               intent(in)    :: iy
   
+      this%SNOWT_AVG = energygrid%SNOWT_AVG(ix,iy)
       this%TV = energygrid%TV(ix,iy)
       this%TG = energygrid%TG(ix,iy)
       this%FCEV = energygrid%FCEV(ix,iy)
@@ -525,6 +527,7 @@ module EnergyType
       integer,               intent(in)    :: ix
       integer,               intent(in)    :: iy
   
+      energygrid%SNOWT_AVG(ix,iy) = this%SNOWT_AVG
       energygrid%TV(ix,iy) = this%TV
       energygrid%TG(ix,iy) = this%TG
       energygrid%FCEV(ix,iy) = this%FCEV

--- a/src/SnowWaterModule.f90
+++ b/src/SnowWaterModule.f90
@@ -30,9 +30,11 @@ contains
 ! ------------------------ local variables ---------------------------
   INTEGER :: IZ,i
   REAL    :: BDSNOW  !bulk density of snow (kg/m3)
+  REAL    :: realMissing
 ! ----------------------------------------------------------------------
 
 ! initialization
+   realMissing = -999999.0
    water%SNOFLOW  = 0.0
    water%PONDING1 = 0.0
    water%PONDING2 = 0.0
@@ -98,7 +100,7 @@ contains
       energy%SNOWT_AVG = SUM(energy%STC(-levels%nsnow+1:0)*(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))) / &
                          SUM(water%SNICE(-levels%nsnow+1:0)+water%SNLIQ(-levels%nsnow+1:0))
    else
-      energy%SNOWT_AVG = huge(1.)
+      energy%SNOWT_AVG = realMissing
    end if
 
   END SUBROUTINE SnowWater

--- a/src/SnowWaterModule.f90
+++ b/src/SnowWaterModule.f90
@@ -30,11 +30,10 @@ contains
 ! ------------------------ local variables ---------------------------
   INTEGER :: IZ,i
   REAL    :: BDSNOW  !bulk density of snow (kg/m3)
-  REAL    :: realMissing
+  REAL    :: realMissing = -999999.0
 ! ----------------------------------------------------------------------
 
 ! initialization
-   realMissing = -999999.0
    water%SNOFLOW  = 0.0
    water%PONDING1 = 0.0
    water%PONDING2 = 0.0

--- a/src/WaterType.f90
+++ b/src/WaterType.f90
@@ -137,6 +137,7 @@ contains
 
     class(water_type), intent(inout) :: this
 
+    this%ACSNOM      = huge(1.0)
     this%qinsur      = huge(1.0)
     this%qseva       = huge(1.0)
     this%EVAPOTRANS  = huge(1.0)
@@ -226,6 +227,7 @@ contains
     integer,              intent(in)    :: ix
     integer,              intent(in)    :: iy
 
+    this%ACSNOM = watergrid%ACSNOM(ix,iy)
     this%qinsur = watergrid%qinsur(ix,iy)
     this%qseva = watergrid%qseva(ix,iy)
     this%EVAPOTRANS = watergrid%EVAPOTRANS(ix,iy)
@@ -306,6 +308,7 @@ contains
     integer,              intent(in)    :: ix
     integer,              intent(in)    :: iy
 
+    watergrid%ACSNOM(ix,iy) = this%ACSNOM
     watergrid%qinsur(ix,iy) = this%qinsur
     watergrid%qseva(ix,iy) = this%qseva
     watergrid%EVAPOTRANS(ix,iy) = this%EVAPOTRANS


### PR DESCRIPTION
# Purpose

To fix handling of `SNOWT_AVG` and `ACSNOM` variables that were added to the gridded branch in PR #86.

# Changes 

- `SNOWT_AVG` was being set to `huge(1.)` when there was no snow/ice. However, this PR changes the way `SNOWT_AVG` calculated such that `SNOWT_AVG` will be `-999999.0` when there is no snow/ice. See PR #91 and [this comment](https://github.com/NOAA-OWP/noah-owp-modular/pull/91#issuecomment-1816587708) specifically for further explanation.

- This PR adds `SNOWT_AVG` to `energy_type%InitDefault`, `energy_type%TransferIn`, and `energy_type%TransferOut` because `SNOWT_AVG` should have been present in these subroutines but was not. This problem surfaced when I reexamined the unit test output for `SNOWT_AVG` (after changing our means of calculating `SNOWT_AVG` as described in the first bullet point above) but did not see expected values for the variable in the unit test output.
    - Note that PR #86 included `SNOWT_AVG` in the transfer in/out subroutines but this change was mistakenly undone by PR #89

- This PR adds `ACSNOM` to `water_type%InitDefault`, `water_type%TransferIn`, and `water_type%TransferOut` because `ACSNOM` should have been present in these subroutines but was not. This problem surfaced when I reexamined the unit test output (after changing our means of calculating `SNOWT_AVG` as described in the first bullet point above) but did not see expected values for the variable in the unit test output.
    - Note that PR #86 included `ACSNOM` in the transfer in/out subroutines but this change was mistakenly undone by PR #89
  
# Testing

- Re-executed unit test and got [this](https://github.com/NOAA-OWP/noah-owp-modular/files/13504018/unit_test_output.txt) output.
