### PR TITLE
Add support for calibratable parameters (lumped version)

### DIFF
--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -689,153 +689,153 @@ contains
               parameters => this%model%parameters)
 
     select case(name)
-    case("SFCPRS")
-       size = sizeof(forcing%sfcprs)  ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SFCTMP")
-       size = sizeof(forcing%sfctmp)             ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SOLDN")
-       size = sizeof(forcing%soldn)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("LWDN")
-       size = sizeof(forcing%lwdn)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("UU")
-       size = sizeof(forcing%uu)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("VV")
-       size = sizeof(forcing%vv)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("Q2")
-       size = sizeof(forcing%q2)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("PRCPNONC")
-       size = sizeof(forcing%prcpnonc)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("QINSUR")
-       size = sizeof(water%qinsur)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("ETRAN")
-       size = sizeof(water%etran)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("QSEVA")
-       size = sizeof(water%qseva)                ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("EVAPOTRANS")
-       size = sizeof(water%evapotrans)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("TG")
-       size = sizeof(energy%tg)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SNEQV")
-       size = sizeof(water%sneqv)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("TGS")
-       size = sizeof(energy%tgs)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
     case("ACSNOM")
-       size = sizeof(water%ACSNOM)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SNOWT_AVG")
-       size = sizeof(energy%SNOWT_AVG)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("ISNOW")
-       size = sizeof(water%ISNOW)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("QRAIN")
-       size = sizeof(water%QRAIN)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("FSNO")
-       size = sizeof(water%FSNO)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SNOWH")
-       size = sizeof(water%SNOWH)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("QSNOW")
-       size = sizeof(water%QSNOW)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("ECAN")
-       size = sizeof(water%ECAN)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("GH")
-       size = sizeof(energy%GH)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("TRAD")
-       size = sizeof(energy%TRAD)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("FSA")
-       size = sizeof(energy%FSA)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("CMC")
-       size = sizeof(water%CMC)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("LH")
-       size = sizeof(energy%LH)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("FIRA")
-       size = sizeof(energy%FIRA)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("FSH")
-       size = sizeof(energy%FSH)            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SNLIQ")
-       size = sizeof(water%SNLIQ(1))            ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("CWP")
-       size = sizeof(parameters%CWP)           ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("VCMX25")
-       size = sizeof(parameters%VCMX25)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("MP")
-       size = sizeof(parameters%MP)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("MFSNO")
-       size = sizeof(parameters%MFSNO)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("RSURF_SNOW")
-       size = sizeof(parameters%RSURF_SNOW)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("HVT")
-       size = sizeof(parameters%HVT)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("BEXP")
-       size = sizeof(parameters%bexp(1))        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SMCMAX")
-       size = sizeof(parameters%smcmax(1))        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("DKSAT")
-       size = sizeof(parameters%dksat(1))        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("RSURF_EXP")
-       size = sizeof(parameters%RSURF_EXP)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("REFKDT")
-       size = sizeof(parameters%refkdt)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
+      size = sizeof(water%ACSNOM)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
     case("AXAJ")
-       size = sizeof(parameters%AXAJ)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
+      size = sizeof(parameters%AXAJ)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("BEXP")
+      size = sizeof(parameters%bexp(1))        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
     case("BXAJ")
-       size = sizeof(parameters%BXAJ)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("XXAJ")
-       size = sizeof(parameters%XXAJ)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
-    case("SLOPE")
-       size = sizeof(parameters%slope)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
+      size = sizeof(parameters%BXAJ)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("CMC")
+      size = sizeof(water%CMC)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("CWP")
+      size = sizeof(parameters%CWP)           ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("DKSAT")
+      size = sizeof(parameters%dksat(1))        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("ECAN")
+      size = sizeof(water%ECAN)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("ETRAN")
+      size = sizeof(water%etran)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("EVAPOTRANS")
+      size = sizeof(water%evapotrans)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("FIRA")
+      size = sizeof(energy%FIRA)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
     case("FRZX")
-       size = sizeof(parameters%frzx)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
+      size = sizeof(parameters%frzx)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("FSA")
+      size = sizeof(energy%FSA)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("FSH")
+      size = sizeof(energy%FSH)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("FSNO")
+      size = sizeof(water%FSNO)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("GH")
+      size = sizeof(energy%GH)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("HVT")
+      size = sizeof(parameters%HVT)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("ISNOW")
+      size = sizeof(water%ISNOW)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
     case("KDT")
-       size = sizeof(parameters%kdt)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
+      size = sizeof(parameters%kdt)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("LH")
+      size = sizeof(energy%LH)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("LWDN")
+      size = sizeof(forcing%lwdn)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("MFSNO")
+      size = sizeof(parameters%MFSNO)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("MP")
+      size = sizeof(parameters%MP)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("PRCPNONC")
+      size = sizeof(forcing%prcpnonc)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("Q2")
+      size = sizeof(forcing%q2)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("QINSUR")
+      size = sizeof(water%qinsur)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("QRAIN")
+      size = sizeof(water%QRAIN)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("QSEVA")
+      size = sizeof(water%qseva)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("QSNOW")
+      size = sizeof(water%QSNOW)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("REFKDT")
+      size = sizeof(parameters%refkdt)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("RSURF_EXP")
+      size = sizeof(parameters%RSURF_EXP)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("RSURF_SNOW")
+      size = sizeof(parameters%RSURF_SNOW)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
     case("SCAMAX")
-       size = sizeof(parameters%SCAMAX)        ! 'sizeof' in gcc & ifort
-       bmi_status = BMI_SUCCESS
+      size = sizeof(parameters%SCAMAX)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SFCPRS")
+      size = sizeof(forcing%sfcprs)  ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SFCTMP")
+      size = sizeof(forcing%sfctmp)             ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SLOPE")
+      size = sizeof(parameters%slope)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SMCMAX")
+      size = sizeof(parameters%smcmax(1))        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SNEQV")
+      size = sizeof(water%sneqv)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SNLIQ")
+      size = sizeof(water%SNLIQ(1))            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SNOWH")
+      size = sizeof(water%SNOWH)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SNOWT_AVG")
+      size = sizeof(energy%SNOWT_AVG)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("SOLDN")
+      size = sizeof(forcing%soldn)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("TG")
+      size = sizeof(energy%tg)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("TGS")
+      size = sizeof(energy%tgs)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("TRAD")
+      size = sizeof(energy%TRAD)            ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("UU")
+      size = sizeof(forcing%uu)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("VCMX25")
+      size = sizeof(parameters%VCMX25)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("VV")
+      size = sizeof(forcing%vv)                ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
+    case("XXAJ")
+      size = sizeof(parameters%XXAJ)        ! 'sizeof' in gcc & ifort
+      bmi_status = BMI_SUCCESS
     case default
        size = -1
        bmi_status = BMI_FAILURE
@@ -918,150 +918,150 @@ contains
               parameters => this%model%parameters)
 
     select case(name)
-    case("SFCPRS")
-       dest = [forcing%sfcprs]
-       bmi_status = BMI_SUCCESS
-    case("SFCTMP")
-       dest = [forcing%sfctmp]
-       bmi_status = BMI_SUCCESS
-    case("SOLDN")
-       dest = [forcing%soldn]
-       bmi_status = BMI_SUCCESS
-    case("LWDN")
-       dest = [forcing%lwdn]
-       bmi_status = BMI_SUCCESS
-    case("UU")
-       dest = [forcing%uu]
-       bmi_status = BMI_SUCCESS
-    case("VV")
-       dest = [forcing%vv]
-       bmi_status = BMI_SUCCESS
-    case("Q2")
-       dest = [forcing%q2]
-       bmi_status = BMI_SUCCESS
-    case("PRCPNONC")
-       dest = [forcing%prcpnonc]
-       bmi_status = BMI_SUCCESS
-    case("QINSUR")
-       dest = [water%qinsur]
-       bmi_status = BMI_SUCCESS
-    case("ETRAN")
-       dest = [water%etran*domain%DT]
-       bmi_status = BMI_SUCCESS
-    case("QSEVA")
-       dest = [water%qseva*m2mm]
-       bmi_status = BMI_SUCCESS
-    case("EVAPOTRANS")
-       dest = [water%evapotrans*domain%DT*mm2m]
-       bmi_status = BMI_SUCCESS
-    case("TG")
-       dest = [energy%tg]
-       bmi_status = BMI_SUCCESS
-    case("SNEQV")
-       dest = [water%sneqv]
-       bmi_status = BMI_SUCCESS
-    case("TGS")
-       dest = [energy%tgs]
-       bmi_status = BMI_SUCCESS
     case("ACSNOM")
-       dest = [water%ACSNOM]
-       bmi_status = BMI_SUCCESS
-    case("SNOWT_AVG")
-       dest = [energy%SNOWT_AVG]
-       bmi_status = BMI_SUCCESS
-    case("QRAIN")
-       dest = [water%QRAIN]
-       bmi_status = BMI_SUCCESS
-    case("FSNO")
-       dest = [water%FSNO]
-       bmi_status = BMI_SUCCESS
-    case("SNOWH")
-       dest = [water%SNOWH]
-       bmi_status = BMI_SUCCESS
-    case("SNLIQ")
-       dest = water%SNLIQ
-       bmi_status = BMI_SUCCESS
-    case("QSNOW")
-       dest = [water%QSNOW]
-       bmi_status = BMI_SUCCESS
-    case("ECAN")
-       dest = [water%ECAN*domain%DT]
-       bmi_status = BMI_SUCCESS
-    case("GH")
-       dest = [energy%GH]
-       bmi_status = BMI_SUCCESS
-    case("TRAD")
-       dest = [energy%TRAD]
-       bmi_status = BMI_SUCCESS
-    case("FSA")
-       dest = [energy%FSA]
-       bmi_status = BMI_SUCCESS
-    case("CMC")
-       dest = [water%CMC]
-       bmi_status = BMI_SUCCESS
-    case("LH")
-       dest = [energy%LH]
-       bmi_status = BMI_SUCCESS
-    case("FIRA")
-       dest = [energy%FIRA]
-       bmi_status = BMI_SUCCESS
-    case("FSH")
-       dest = [energy%FSH]
-       bmi_status = BMI_SUCCESS
-    case("CWP")
-       dest = [parameters%CWP]
-       bmi_status = BMI_SUCCESS
-    case("VCMX25")
-       dest = [parameters%VCMX25]
-       bmi_status = BMI_SUCCESS
-    case("MP")
-       dest = [parameters%MP]
-       bmi_status = BMI_SUCCESS
-    case("MFSNO")
-       dest = [parameters%MFSNO]
-       bmi_status = BMI_SUCCESS
-    case("RSURF_SNOW")
-       dest = [parameters%RSURF_SNOW]
-       bmi_status = BMI_SUCCESS
-    case("HVT")
-       dest = [parameters%HVT]
-       bmi_status = BMI_SUCCESS
-    case("BEXP")
-       dest = [parameters%bexp]
-       bmi_status = BMI_SUCCESS
-    case("SMCMAX")
-       dest = [parameters%smcmax]
-       bmi_status = BMI_SUCCESS
-    case("FRZX")
-       dest = [parameters%frzx]
-       bmi_status = BMI_SUCCESS
-    case("DKSAT")
-       dest = [parameters%dksat]
-       bmi_status = BMI_SUCCESS
-    case("KDT")
-       dest = [parameters%kdt]
-       bmi_status = BMI_SUCCESS
-    case("RSURF_EXP")
-       dest = [parameters%RSURF_EXP]
-       bmi_status = BMI_SUCCESS
-    case("REFKDT")
-       dest = [parameters%refkdt]
-       bmi_status = BMI_SUCCESS
+      dest = [water%ACSNOM]
+      bmi_status = BMI_SUCCESS
     case("AXAJ")
-       dest = [parameters%AXAJ]
-       bmi_status = BMI_SUCCESS
+      dest = [parameters%AXAJ]
+      bmi_status = BMI_SUCCESS
+    case("BEXP")
+      dest = [parameters%bexp]
+      bmi_status = BMI_SUCCESS
     case("BXAJ")
-       dest = [parameters%BXAJ]
-       bmi_status = BMI_SUCCESS
-    case("XXAJ")
-       dest = [parameters%XXAJ]
-       bmi_status = BMI_SUCCESS
-    case("SLOPE")
-       dest = [parameters%slope]
-       bmi_status = BMI_SUCCESS
+      dest = [parameters%BXAJ]
+      bmi_status = BMI_SUCCESS
+    case("CMC")
+      dest = [water%CMC]
+      bmi_status = BMI_SUCCESS
+    case("CWP")
+      dest = [parameters%CWP]
+      bmi_status = BMI_SUCCESS
+    case("DKSAT")
+      dest = [parameters%dksat]
+      bmi_status = BMI_SUCCESS
+    case("ECAN")
+      dest = [water%ECAN*domain%DT]
+      bmi_status = BMI_SUCCESS
+    case("ETRAN")
+      dest = [water%etran*domain%DT]
+      bmi_status = BMI_SUCCESS
+    case("EVAPOTRANS")
+      dest = [water%evapotrans*domain%DT*mm2m]
+      bmi_status = BMI_SUCCESS
+    case("FIRA")
+      dest = [energy%FIRA]
+      bmi_status = BMI_SUCCESS
+    case("FRZX")
+      dest = [parameters%frzx]
+      bmi_status = BMI_SUCCESS
+    case("FSA")
+      dest = [energy%FSA]
+      bmi_status = BMI_SUCCESS
+    case("FSH")
+      dest = [energy%FSH]
+      bmi_status = BMI_SUCCESS
+    case("FSNO")
+      dest = [water%FSNO]
+      bmi_status = BMI_SUCCESS
+    case("GH")
+      dest = [energy%GH]
+      bmi_status = BMI_SUCCESS
+    case("HVT")
+      dest = [parameters%HVT]
+      bmi_status = BMI_SUCCESS
+    case("KDT")
+      dest = [parameters%kdt]
+      bmi_status = BMI_SUCCESS
+    case("LH")
+      dest = [energy%LH]
+      bmi_status = BMI_SUCCESS
+    case("LWDN")
+      dest = [forcing%lwdn]
+      bmi_status = BMI_SUCCESS
+    case("MFSNO")
+      dest = [parameters%MFSNO]
+      bmi_status = BMI_SUCCESS
+    case("MP")
+      dest = [parameters%MP]
+      bmi_status = BMI_SUCCESS
+    case("PRCPNONC")
+      dest = [forcing%prcpnonc]
+      bmi_status = BMI_SUCCESS
+    case("Q2")
+      dest = [forcing%q2]
+      bmi_status = BMI_SUCCESS
+    case("QINSUR")
+      dest = [water%qinsur]
+      bmi_status = BMI_SUCCESS
+    case("QRAIN")
+      dest = [water%QRAIN]
+      bmi_status = BMI_SUCCESS
+    case("QSEVA")
+      dest = [water%qseva*m2mm]
+      bmi_status = BMI_SUCCESS
+    case("QSNOW")
+      dest = [water%QSNOW]
+      bmi_status = BMI_SUCCESS
+    case("REFKDT")
+      dest = [parameters%refkdt]
+      bmi_status = BMI_SUCCESS
+    case("RSURF_EXP")
+      dest = [parameters%RSURF_EXP]
+      bmi_status = BMI_SUCCESS
+    case("RSURF_SNOW")
+      dest = [parameters%RSURF_SNOW]
+      bmi_status = BMI_SUCCESS
     case("SCAMAX")
-       dest = [parameters%SCAMAX]
-       bmi_status = BMI_SUCCESS
+      dest = [parameters%SCAMAX]
+      bmi_status = BMI_SUCCESS    
+    case("SFCPRS")
+      dest = [forcing%sfcprs]
+      bmi_status = BMI_SUCCESS
+    case("SFCTMP")
+      dest = [forcing%sfctmp]
+      bmi_status = BMI_SUCCESS
+    case("SLOPE")
+      dest = [parameters%slope]
+      bmi_status = BMI_SUCCESS
+    case("SMCMAX")
+      dest = [parameters%smcmax]
+      bmi_status = BMI_SUCCESS
+    case("SNEQV")
+      dest = [water%sneqv]
+      bmi_status = BMI_SUCCESS
+    case("SNLIQ")
+      dest = [water%SNLIQ]
+      bmi_status = BMI_SUCCESS
+    case("SNOWH")
+      dest = [water%SNOWH]
+      bmi_status = BMI_SUCCESS
+    case("SNOWT_AVG")
+      dest = [energy%SNOWT_AVG]
+      bmi_status = BMI_SUCCESS
+    case("SOLDN")
+      dest = [forcing%soldn]
+      bmi_status = BMI_SUCCESS
+    case("TG")
+      dest = [energy%tg]
+      bmi_status = BMI_SUCCESS
+    case("TGS")
+      dest = [energy%tgs]
+      bmi_status = BMI_SUCCESS
+    case("TRAD")
+      dest = [energy%TRAD]
+      bmi_status = BMI_SUCCESS
+    case("UU")
+      dest = [forcing%uu]
+      bmi_status = BMI_SUCCESS
+    case("VCMX25")
+      dest = [parameters%VCMX25]
+      bmi_status = BMI_SUCCESS
+    case("VV")
+      dest = [forcing%vv]
+      bmi_status = BMI_SUCCESS
+    case("XXAJ")
+      dest = [parameters%XXAJ]
+      bmi_status = BMI_SUCCESS
     case default
        dest(:) = -1.0
        bmi_status = BMI_FAILURE
@@ -1231,108 +1231,108 @@ contains
               parameters => this%model%parameters)
 
     select case(name)
-    case("SFCPRS")
-       forcing%sfcprs = src(1)
-       bmi_status = BMI_SUCCESS
-    case("SFCTMP")
-       forcing%sfctmp = src(1)
-       bmi_status = BMI_SUCCESS
-    case("SOLDN")
-       forcing%soldn = src(1)
-       bmi_status = BMI_SUCCESS
-    case("LWDN")
-       forcing%lwdn = src(1)
-       bmi_status = BMI_SUCCESS
-    case("UU")
-       forcing%uu = src(1)
-       bmi_status = BMI_SUCCESS
-    case("VV")
-       forcing%vv = src(1)
-       bmi_status = BMI_SUCCESS
-    case("Q2")
-       forcing%q2 = src(1)
-       bmi_status = BMI_SUCCESS
-    case("PRCPNONC")
-       forcing%prcpnonc = src(1)
-       bmi_status = BMI_SUCCESS
-    case("QINSUR")
-       water%qinsur = src(1)
-       bmi_status = BMI_SUCCESS
-    case("ETRAN")
-       water%etran = src(1) / domain%DT
-       bmi_status = BMI_SUCCESS
-    case("QSEVA")
-       water%qseva = src(1) * mm2m 
-       bmi_status = BMI_SUCCESS
-    case("EVAPOTRANS")
-       water%evapotrans = src(1) * m2mm / domain%DT
-       bmi_status = BMI_SUCCESS
-    case("TG")
-       energy%tg = src(1)
-       bmi_status = BMI_SUCCESS
-    case("SNEQV")
-       water%sneqv = src(1)
-       bmi_status = BMI_SUCCESS
-    case("TGS")
-       energy%tgs = src(1)
-       bmi_status = BMI_SUCCESS
-    case("CWP")
-       parameters%CWP = src(1)
-       bmi_status = BMI_SUCCESS
-    case("VCMX25")
-       parameters%VCMX25 = src(1)
-       bmi_status = BMI_SUCCESS
-    case("MP")
-       parameters%MP = src(1)
-       bmi_status = BMI_SUCCESS
-    case("MFSNO")
-       parameters%MFSNO = src(1)
-       bmi_status = BMI_SUCCESS
-    case("RSURF_SNOW")
-       parameters%RSURF_SNOW = src(1)
-       bmi_status = BMI_SUCCESS
-    case("HVT")
-       parameters%HVT = src(1)
-       bmi_status = BMI_SUCCESS
-    case("BEXP")
-       parameters%bexp(:) = src(:)
-       bmi_status = BMI_SUCCESS
-    case("SMCMAX")
-       parameters%smcmax(:) = src(:)
-       parameters%frzx      = 0.15 * (parameters%smcmax(1) / parameters%smcref(1)) * (0.412 / 0.468)
-       bmi_status = BMI_SUCCESS
-    case("DKSAT")
-       parameters%dksat(:) = src(:)
-       parameters%kdt     = parameters%refkdt * parameters%dksat(1) / parameters%refdk
-       bmi_status = BMI_SUCCESS
-    case("KDT")
-       parameters%KDT = src(1)
-       bmi_status = BMI_SUCCESS
-    case("RSURF_EXP")
-       parameters%RSURF_EXP = src(1)
-       bmi_status = BMI_SUCCESS
-    case("REFKDT")
-       parameters%refkdt = src(1)
-       parameters%kdt     = parameters%refkdt * parameters%dksat(1) / parameters%refdk
-       bmi_status = BMI_SUCCESS
     case("AXAJ")
-       parameters%AXAJ = src(1)
-       bmi_status = BMI_SUCCESS
+      parameters%AXAJ = src(1)
+      bmi_status = BMI_SUCCESS
+    case("BEXP")
+      parameters%bexp(:) = src(:)
+      bmi_status = BMI_SUCCESS
     case("BXAJ")
-       parameters%BXAJ = src(1)
-       bmi_status = BMI_SUCCESS
-    case("XXAJ")
-       parameters%XXAJ = src(1)
-       bmi_status = BMI_SUCCESS
-    case("SLOPE")
-       parameters%slope = src(1)
-       bmi_status = BMI_SUCCESS
-    case("SCAMAX")
-       parameters%SCAMAX = src(1)
-       bmi_status = BMI_SUCCESS
+      parameters%BXAJ = src(1)
+      bmi_status = BMI_SUCCESS
+    case("CWP")
+      parameters%CWP = src(1)
+      bmi_status = BMI_SUCCESS
+    case("DKSAT")
+      parameters%dksat(:) = src(:)
+      parameters%kdt     = parameters%refkdt * parameters%dksat(1) / parameters%refdk
+      bmi_status = BMI_SUCCESS
+    case("ETRAN")
+      water%etran = src(1) / domain%DT
+      bmi_status = BMI_SUCCESS
+    case("EVAPOTRANS")
+      water%evapotrans = src(1) * m2mm / domain%DT
+      bmi_status = BMI_SUCCESS
     case("FRZX")
-       parameters%FRZX = src(1)
-       bmi_status = BMI_SUCCESS
+      parameters%FRZX = src(1)
+      bmi_status = BMI_SUCCESS
+    case("HVT")
+      parameters%HVT = src(1)
+      bmi_status = BMI_SUCCESS
+    case("KDT")
+      parameters%KDT = src(1)
+      bmi_status = BMI_SUCCESS
+    case("LWDN")
+      forcing%lwdn = src(1)
+      bmi_status = BMI_SUCCESS
+    case("MFSNO")
+      parameters%MFSNO = src(1)
+      bmi_status = BMI_SUCCESS
+    case("MP")
+      parameters%MP = src(1)
+      bmi_status = BMI_SUCCESS
+    case("PRCPNONC")
+      forcing%prcpnonc = src(1)
+      bmi_status = BMI_SUCCESS
+    case("Q2")
+      forcing%q2 = src(1)
+      bmi_status = BMI_SUCCESS
+    case("QINSUR")
+      water%qinsur = src(1)
+      bmi_status = BMI_SUCCESS
+    case("QSEVA")
+      water%qseva = src(1) * mm2m 
+      bmi_status = BMI_SUCCESS
+    case("REFKDT")
+      parameters%refkdt = src(1)
+      parameters%kdt     = parameters%refkdt * parameters%dksat(1) / parameters%refdk
+      bmi_status = BMI_SUCCESS
+    case("RSURF_EXP")
+      parameters%RSURF_EXP = src(1)
+      bmi_status = BMI_SUCCESS
+    case("RSURF_SNOW")
+      parameters%RSURF_SNOW = src(1)
+      bmi_status = BMI_SUCCESS
+    case("SCAMAX")
+      parameters%SCAMAX = src(1)
+      bmi_status = BMI_SUCCESS
+    case("SFCPRS")
+      forcing%sfcprs = src(1)
+      bmi_status = BMI_SUCCESS
+    case("SFCTMP")
+      forcing%sfctmp = src(1)
+      bmi_status = BMI_SUCCESS
+    case("SLOPE")
+      parameters%slope = src(1)
+      bmi_status = BMI_SUCCESS
+    case("SMCMAX")
+      parameters%smcmax(:) = src(:)
+      parameters%frzx      = 0.15 * (parameters%smcmax(1) / parameters%smcref(1)) * (0.412 / 0.468)
+      bmi_status = BMI_SUCCESS
+    case("SNEQV")
+      water%sneqv = src(1)
+      bmi_status = BMI_SUCCESS
+    case("SOLDN")
+      forcing%soldn = src(1)
+      bmi_status = BMI_SUCCESS
+    case("TG")
+      energy%tg = src(1)
+      bmi_status = BMI_SUCCESS
+    case("TGS")
+      energy%tgs = src(1)
+      bmi_status = BMI_SUCCESS
+    case("UU")
+      forcing%uu = src(1)
+      bmi_status = BMI_SUCCESS
+    case("VCMX25")
+      parameters%VCMX25 = src(1)
+      bmi_status = BMI_SUCCESS
+    case("VV")
+      forcing%vv = src(1)
+      bmi_status = BMI_SUCCESS
+    case("XXAJ")
+      parameters%XXAJ = src(1)
+      bmi_status = BMI_SUCCESS
     case default
        bmi_status = BMI_FAILURE
     end select

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -106,14 +106,6 @@ module bminoahowp
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(output_item_count) :: output_items 
 
-  character(len=BMI_MAX_VAR_NAME), &
-       dimension(param_item_count) :: param_items = &
-       [character(len=BMI_MAX_VAR_NAME) :: &
-       "CWP","VCMX25","MP","MFSNO","RSURF_SNOW","HVT", & 
-       "BEXP","SMCMAX","FRZX","DKSAT","KDT","RSURF_EXP","REFKDT", &
-       "AXAJ","BXAJ","XXAJ","SLOPE","SCAMAX"]
-   integer, dimension(param_item_count) :: param_grid = 0
-
 contains
 
   ! Get the name of the model.
@@ -393,6 +385,12 @@ contains
 !     case(1)
 !        shape(:) = [this%model%n_y, this%model%n_x]
 !        bmi_status = BMI_SUCCESS
+    case (1)
+       shape(:) = [this%model%levels%nsnow]
+       bmi_status = BMI_SUCCESS
+    case (2)
+       shape(:) = [this%model%levels%nsoil]
+       bmi_status = BMI_SUCCESS
     case default
        shape(:) = -1
        bmi_status = BMI_FAILURE
@@ -608,8 +606,8 @@ contains
     case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! forcing vars
        'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS', 'ACSNOM', 'SNOWT_AVG', &      ! output vars
        'QRAIN', 'FSNO', 'SNOWH', 'SNLIQ', 'QSNOW', 'ECAN', 'GH', 'TRAD', 'FSA', 'CMC', 'LH', 'FIRA', 'FSH', &
-       'CWP','VCMX25','MP','MFSNO','RSURF_SNOW','HVT','FRXZ','KDT','RSURF_EXP','REFKDT', &
-       'AXAJ','BXAJ','XXAJ','SLOPE','SCAMAX')
+       'CWP','VCMX25','MP','MFSNO','RSURF_SNOW','HVT','FRZX','KDT','RSURF_EXP','REFKDT', &
+       'AXAJ','BXAJ','XXAJ','SLOPE','SCAMAX','BEXP','SMCMAX','DKSAT')
        type = "real"
        bmi_status = BMI_SUCCESS
     case('ISNOW')

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -99,7 +99,6 @@ module bminoahowp
   ! Exchange items
   integer, parameter :: input_item_count = 8
   integer, parameter :: output_item_count = 23
-  
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -383,10 +383,10 @@ contains
 !        shape(:) = [this%model%n_y, this%model%n_x]
 !        bmi_status = BMI_SUCCESS
     case (1)
-       shape(:) = [this%model%levels%nsnow]
+       shape(:) = this%model%levels%nsnow
        bmi_status = BMI_SUCCESS
     case (2)
-       shape(:) = [this%model%levels%nsoil]
+       shape(:) = this%model%levels%nsoil
        bmi_status = BMI_SUCCESS
     case default
        shape(:) = -1

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -301,18 +301,19 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! input vars
-         'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS',    & ! output vars
-         'ACSNOM','SNOWT_AVG','ISNOW','QRAIN','FSNO','SNOWH','QSNOW',       &
-         'ECAN','GH','TRAD','FSA','CMC','LH','FIRA','FSH','CWP','VCMX25',   &
-         'MP','MFSNO','RSURF_SNOW','HVT','FRZX','KDT','RSURF_EXP','REFKDT', &
-         'AXAJ','BXAJ','XXAJ','SLOPE','SCAMAX')
+    case('ACSNOM', 'AXAJ', 'BXAJ', 'CMC', 'CWP', 'ECAN', 'ETRAN',            &
+         'EVAPOTRANS', 'FIRA', 'FRZX', 'FSA', 'FSH', 'FSNO', 'GH',           &
+         'HVT', 'ISNOW', 'KDT', 'LH', 'LWDN', 'MFSNO', 'MP', 'PRCPNONC',     &
+         'Q2', 'QINSUR', 'QRAIN', 'QSEVA', 'QSNOW', 'REFKDT', 'RSURF_EXP',   &
+         'RSURF_SNOW', 'SCAMAX', 'SFCPRS', 'SFCTMP', 'SLOPE', 'SNEQV',       &
+         'SNOWH', 'SNOWT_AVG', 'SOLDN', 'TG', 'TGS', 'TRAD', 'UU', 'VCMX25', &
+         'VV', 'XXAJ')
          grid = 0
          bmi_status = BMI_SUCCESS
     case('SNLIQ')
          grid = 1
          bmi_status = BMI_SUCCESS
-    case('BEXP','SMCMAX','DKSAT')
+    case('BEXP','DKSAT','SMCMAX')
          grid = 2
          bmi_status = BMI_SUCCESS
     case default
@@ -600,11 +601,13 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case('SFCPRS', 'SFCTMP', 'SOLDN', 'LWDN', 'UU', 'VV', 'Q2', 'PRCPNONC', & ! forcing vars
-       'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS', 'ACSNOM', 'SNOWT_AVG', &      ! output vars
-       'QRAIN', 'FSNO', 'SNOWH', 'SNLIQ', 'QSNOW', 'ECAN', 'GH', 'TRAD', 'FSA', 'CMC', 'LH', 'FIRA', 'FSH', &
-       'CWP','VCMX25','MP','MFSNO','RSURF_SNOW','HVT','FRZX','KDT','RSURF_EXP','REFKDT', &
-       'AXAJ','BXAJ','XXAJ','SLOPE','SCAMAX','BEXP','SMCMAX','DKSAT')
+    case('ACSNOM', 'AXAJ', 'BEXP', 'BXAJ', 'CMC', 'CWP', 'DKSAT',          &
+         'ECAN', 'ETRAN', 'EVAPOTRANS', 'FIRA', 'FRZX', 'FSA', 'FSH',      &
+         'FSNO', 'GH', 'HVT', 'KDT', 'LH', 'LWDN', 'MFSNO', 'MP',          &
+         'PRCPNONC', 'Q2', 'QINSUR', 'QRAIN', 'QSEVA', 'QSNOW', 'REFKDT',  &
+         'RSURF_EXP', 'RSURF_SNOW', 'SCAMAX', 'SFCPRS', 'SFCTMP', 'SLOPE', &
+         'SMCMAX', 'SNEQV', 'SNLIQ', 'SNOWH', 'SNOWT_AVG', 'SOLDN', 'TG',  &
+         'TGS', 'TRAD', 'UU', 'VCMX25', 'VV', 'XXAJ')
        type = "real"
        bmi_status = BMI_SUCCESS
     case('ISNOW')

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -152,7 +152,6 @@ contains
     input_items(7) = 'Q2'       ! mixing ratio (kg/kg)
     input_items(8) = 'PRCPNONC' ! precipitation rate (mm/s)
     
-
     names => input_items
     bmi_status = BMI_SUCCESS
   end function noahowp_input_var_names
@@ -307,7 +306,7 @@ contains
          'QINSUR', 'ETRAN', 'QSEVA', 'EVAPOTRANS', 'TG', 'SNEQV', 'TGS',    & ! output vars
          'ACSNOM','SNOWT_AVG','ISNOW','QRAIN','FSNO','SNOWH','QSNOW',       &
          'ECAN','GH','TRAD','FSA','CMC','LH','FIRA','FSH','CWP','VCMX25',   &
-         'MP','MFSNO','RSURF_SNOW','HVT','FRXZ','KDT','RSURF_EXP','REFKDT', &
+         'MP','MFSNO','RSURF_SNOW','HVT','FRZX','KDT','RSURF_EXP','REFKDT', &
          'AXAJ','BXAJ','XXAJ','SLOPE','SCAMAX')
          grid = 0
          bmi_status = BMI_SUCCESS
@@ -1304,6 +1303,9 @@ contains
        parameters%dksat(:) = src(:)
        parameters%kdt     = parameters%refkdt * parameters%dksat(1) / parameters%refdk
        bmi_status = BMI_SUCCESS
+    case("KDT")
+       parameters%KDT = src(1)
+       bmi_status = BMI_SUCCESS
     case("RSURF_EXP")
        parameters%RSURF_EXP = src(1)
        bmi_status = BMI_SUCCESS
@@ -1325,6 +1327,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("SCAMAX")
        parameters%SCAMAX = src(1)
+       bmi_status = BMI_SUCCESS
+    case("FRZX")
+       parameters%FRZX = src(1)
        bmi_status = BMI_SUCCESS
     case default
        bmi_status = BMI_FAILURE

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -99,7 +99,6 @@ module bminoahowp
   ! Exchange items
   integer, parameter :: input_item_count = 8
   integer, parameter :: output_item_count = 23
-  integer, parameter :: param_item_count = 18 
   
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items

--- a/src/EnergyModule.f90
+++ b/src/EnergyModule.f90
@@ -85,7 +85,7 @@ contains
     IF(water%SNOWH > 0.0)  THEN
       water%BDSNO  = water%SNEQV / water%SNOWH
       FMELT        = (water%BDSNO / 100.)**parameters%MFSNO
-      water%FSNO   = TANH( water%SNOWH /(2.5 * parameters%Z0 * FMELT)) ! eq. 4 from Niu and Yang (2007)
+      water%FSNO   = parameters%SCAMAX * TANH( water%SNOWH /(2.5 * parameters%Z0 * FMELT)) ! eq. 4 from Niu and Yang (2007)
     ENDIF
 
     ! Compute ground roughness length

--- a/src/ParametersType.f90
+++ b/src/ParametersType.f90
@@ -142,7 +142,8 @@ type, public :: parameters_type
   real                            :: TBOT                      ! bottom condition for soil temp. (k)
   real                            :: GRAV                      ! acceleration due to gravity (m/s2)
   real                            :: rain_snow_thresh          ! user-defined rain-snow temperature threshold (°C)
-
+  real                            :: SCAMAX                    ! maximum fractional snow-covered area
+  
   contains
 
     procedure, public  :: Init
@@ -193,6 +194,7 @@ contains
     this%VAI        = huge(1.0)
     this%VEG        = .true.
     this%FVEG       = huge(1.0)
+    this%SCAMAX     = 1.
 
   end subroutine InitDefault
 

--- a/test/noahowp_driver_test.f90
+++ b/test/noahowp_driver_test.f90
@@ -93,7 +93,7 @@ program noahmp_driver_test
     n_outputs = count
 
     count = size(names_params)
-    write(*,'(a,I5)') "Total calibratable parameters = ", count
+    print*, "Total calibratable parameters = ", count
     n_params = count
 
     status = m%get_input_var_names(names_inputs)

--- a/test/noahowp_driver_test.f90
+++ b/test/noahowp_driver_test.f90
@@ -47,6 +47,7 @@ program noahmp_driver_test
     double precision                                  :: current_time     ! current model time
     character (len = 1)                               :: ts_units         ! timestep units
     real, allocatable, target                         :: var_value_get_real(:) ! value of a variable
+    real, allocatable, target                         :: var_value_get_real_temp(:) ! value of a variable
     real, allocatable                                 :: var_value_set_real(:) ! value of a variable
     integer, allocatable, target                      :: var_value_get_int(:) ! value of a variable
     integer, allocatable                              :: var_value_set_int(:) ! value of a variable
@@ -61,7 +62,7 @@ program noahmp_driver_test
     double precision, dimension(1)                    :: grid_x           ! X coordinate of grid nodes (change dims if multiple nodes)
     double precision, dimension(1)                    :: grid_y           ! Y coordinate of grid nodes (change dims if multiple nodes)
     double precision, dimension(1)                    :: grid_z           ! Y coordinate of grid nodes (change dims if multiple nodes)
-    
+    real                                              :: temp_scalar
     real, pointer                                     :: var_value_get_real_ptr(:) ! value of a variable for get_value_ptr
     integer, pointer                                  :: var_value_get_int_ptr(:) ! value of a variable for get_value_ptr
 
@@ -214,10 +215,50 @@ program noahmp_driver_test
         var_value_set_real = 999
         status = m%get_value(trim(name), var_value_get_real)
         print*, trim(name), " from get_value = ", var_value_get_real
+        select case (trim(name))
+        case('SMCMAX')
+          if(allocated(var_value_get_real_temp)) deallocate(var_value_get_real_temp)
+          allocate(var_value_get_real_temp(1))
+          status = m%get_value('FRZX', var_value_get_real_temp)
+          print*,"    (FRZX is recalculated by setting SMCMAX)"
+          print*,"    from get_value (for FRZX)= ", var_value_get_real_temp
+        case('DKSAT')
+          if(allocated(var_value_get_real_temp)) deallocate(var_value_get_real_temp)
+          allocate(var_value_get_real_temp(1))
+          status = m%get_value('KDT', var_value_get_real_temp)
+          print*,"    (KDT is recalculated by setting DKSAT)"
+          print*,"    from get_value (for KDT)= ", var_value_get_real_temp
+        case('REFKDT')
+          if(allocated(var_value_get_real_temp)) deallocate(var_value_get_real_temp)
+          allocate(var_value_get_real_temp(1))
+          status = m%get_value('KDT', var_value_get_real_temp)
+          print*,"    (KDT is recalculated by setting REFKDT)"
+          print*,"    from get_value (for KDT)= ", var_value_get_real_temp
+        end select
         print*, "    our replacement value = ", var_value_set_real
         status = m%set_value(trim(name), var_value_set_real)
         status = m%get_value(trim(name), var_value_get_real)
         print*, "    and the new value of ", trim(name), " = ", var_value_get_real
+        select case (trim(name))
+        case('SMCMAX')
+          if(allocated(var_value_get_real_temp)) deallocate(var_value_get_real_temp)
+          allocate(var_value_get_real_temp(1))
+          status = m%get_value('FRZX', var_value_get_real_temp)
+          print*,"    (FRZX is recalculated by setting SMCMAX)"
+          print*,"    from get_value (for FRZX)= ", var_value_get_real_temp
+        case('DKSAT')
+          if(allocated(var_value_get_real_temp)) deallocate(var_value_get_real_temp)
+          allocate(var_value_get_real_temp(1))
+          status = m%get_value('KDT', var_value_get_real_temp)
+          print*,"    (KDT is recalculated by setting DKSAT)"
+          print*,"    from get_value (for KDT)= ", var_value_get_real_temp
+        case('REFKDT')
+          if(allocated(var_value_get_real_temp)) deallocate(var_value_get_real_temp)
+          allocate(var_value_get_real_temp(1))
+          status = m%get_value('KDT', var_value_get_real_temp)
+          print*,"    (KDT is recalculated by setting REFKDT)"
+          print*,"    from get_value (for KDT)= ", var_value_get_real_temp
+        end select
       end if
     end do
     


### PR DESCRIPTION
# Purpose

This PR exposes the model's calibratable parameters via its BMI so that they can be calibrated via NextGen. This PR exposes these parameters in the lumped (i.e., non-gridded) version of Noah-OWP-Modular.

# Additions

## Calibratable parameters

The following parameters were added to the model's BMI:
- `BEXP`
- `SMCMAX`
- `DKSAT`
- `RSURF_EXP`
- `REFKDT`
- `AXAJ`
- `BXAJ`
- `XXAJ`
- `SLOPE`
- `CWP`
- `VCMX25`
- `MP`
- `MFSNO`
- `SCAMAX`***
- `RSURF_SNOW`
- `HVT`
- `FRZX`**
- `KDT`**

** `FRZX` and `KDT` were added because they are recalculated/reinitialized when setting `SMCMAX`, `DKSAT` and/or `REFKDT`. `FRZX` and `KDT` were added so that they may be included in the unit test program; they are not intended to be calibrated.

*** This PR adds `SCAMAX` to Noah-OWP-Modular because it is a NWM 3.0 calibratable parameter. `SCAMAX` was added as a member of `parameters_type`. The calculation of `FSNO` (i.e., snow covered area) was amended to follow [WRF-Hydro's calculation](https://github.com/NCAR/wrf_hydro_nwm_public/blob/3deb607cd07236794af3140d4778d7da2d776b5e/src/Land_models/NoahMP/phys/module_sf_noahmplsm.F#L1839) as:

`water%FSNO   = parameters%SCAMAX * TANH( water%SNOWH /(2.5 * parameters%Z0 * FMELT))`

# Changes

The Noah-OWP-Modular unit test program (`/test/noahowp_driver_test.f90`) was updated to facilitate testing of the calibratable parameters.

# Testing

The refactored unit test program was executed and gave these [results](https://github.com/NOAA-OWP/noah-owp-modular/files/14578165/noahowp_test_output.txt).


# Notes

This PR replicates PR #95, which exposed the calibratable parameters for the gridded version of Noah-OWP-Modular.