### PR TITLE
don't initialize ngen submodule after copying in local code

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -98,6 +98,8 @@ jobs:
         with:
           mod-dir: " extern/noah-owp-modular/"
           targets: "surfacebmi"
+          initialize: "false"
+          cmake-flags: "-DNGEN_IS_MAIN_PROJECT:BOOL=ON"
 
       - name: Run Ngen Test
         run: |


### PR DESCRIPTION
This PR, dependent on noaa-owp/ngen#769, would allow the integration test to use the current checked out code in place of the submodule checkout by using the new "initialize" input.  This also passes custom cmake build flags along to the submodule build action to configure the build.

This allows the ngen build to use the static submodule commits (which have hopefully been tested) and only use the current NOM PR code to run the test with.  Customization of other components is possible, but not in scope here and may not be a good idea in general.

Closes #104 