### PR TITLE
Correct `OptionsType` subroutine's `this` parameter `intent`; Use `brew --prefix` to resolve the correct platform specific `brew` prefix

### DIFF
--- a/.github/workflows/Build_and_Run_Standalone_Test.yml
+++ b/.github/workflows/Build_and_Run_Standalone_Test.yml
@@ -42,10 +42,10 @@ jobs:
         elif [ ${{ runner.os }} == 'macOS' ]
         then
           brew install netcdf netcdf-cxx netcdf-fortran
-          echo "LIBRARY_PATH=/usr/local/lib/:$LIBRARY_PATH" >> $GITHUB_ENV
-          echo "LDFLAGS=-L/usr/local/lib" >> $GITHUB_ENV
-          echo "INCLUDE=/usr/local/include" >> $GITHUB_ENV
-          echo "NETCDF=/usr/local" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=$(brew --prefix)/lib/:$LIBRARY_PATH" >> $GITHUB_ENV
+          echo "LDFLAGS=-L$(brew --prefix)/lib" >> $GITHUB_ENV
+          echo "INCLUDE=$(brew --prefix)/include" >> $GITHUB_ENV
+          echo "NETCDF=$(brew --prefix)" >> $GITHUB_ENV
         fi
     
     # Build and run noah executable

--- a/src/OptionsType.f90
+++ b/src/OptionsType.f90
@@ -118,7 +118,7 @@ contains
 
   subroutine Init(this)
 
-    class(options_type), intent(out) :: this
+    class(options_type), intent(inout) :: this
 
     call this%InitDefault()
 
@@ -126,7 +126,7 @@ contains
 
   subroutine InitDefault(this)
 
-    class(options_type), intent(out) :: this
+    class(options_type), intent(inout) :: this
 
     this%opt_snf   = huge(1)
     this%opt_run   = huge(1)
@@ -150,7 +150,7 @@ contains
 
   subroutine InitTransfer(this, namelist)
 
-    class(options_type), intent(out) :: this
+    class(options_type), intent(inout) :: this
     type(namelist_type), intent(in)  :: namelist
 
     this%opt_snf   = namelist%precip_phase_option


### PR DESCRIPTION
## Change:
- Correct `OptionsType` subroutine's `this` parameter `intent` to `inout`. `aarm` `gfortran` compilers appear to be more strict and do not generate the same symbols as other compilers. This results in linking errors (see comments below). Similar to https://github.com/NOAA-OWP/snow17/issues/37

## CI:
On intel macOS, brew installs into `/usr/local`
On apple silicon, brew installs into `/opt/homebrew`

Use `brew --prefix` to resolve the right brew prefix in a platform independent manor